### PR TITLE
[FIX][PyCryptoBot.py] Invoke api.marketSell on SELL order

### DIFF
--- a/models/PyCryptoBot.py
+++ b/models/PyCryptoBot.py
@@ -674,10 +674,10 @@ class PyCryptoBot():
     def marketSell(self, market, base_currency):
         if self.exchange == 'coinbasepro':
             api = CBAuthAPI(self.getAPIKey(), self.getAPISecret(), self.getAPIPassphrase(), self.getAPIURL())
-            return api.marketBuy(market, base_currency)
+            return api.marketSell(market, base_currency)
         elif self.exchange == 'binance':
             api = BAuthAPI(self.getAPIKey(), self.getAPISecret(), self.getAPIURL())
-            return api.marketBuy(market, base_currency)
+            return api.marketSell(market, base_currency)
         else:
             return None
 


### PR DESCRIPTION
There is a copy-error, invoking api.marketBuy on the marketSell.
This triggers the "raise ValueError('Trade amount is too small (>= 10).')" and the bot stops.