### PR TITLE
Add container image build to repo

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -5,6 +5,7 @@ on:
     # Publish `main` as Docker `latest` image.
     branches:
       - main
+      - docker
 
     # Publish `v1.2.3` tags as releases.
     tags:

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -1,4 +1,4 @@
-name: Docker
+name: Container
 
 on:
   push:
@@ -15,33 +15,12 @@ on:
   pull_request:
 
 env:
-  # TODO: Change variable to your image's name.
   IMAGE_NAME: pycryptobot
 
 jobs:
-  # Run tests.
-  # See also https://docs.docker.com/docker-hub/builds/automated-testing/
-  test:
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v2
-
-      - name: Run tests
-        run: |
-          if [ -f docker-compose.test.yml ]; then
-            docker-compose --file docker-compose.test.yml build
-            docker-compose --file docker-compose.test.yml run sut
-          else
-            docker build . --file Dockerfile
-          fi
-
-  # Push image to GitHub Packages.
+  # Build and push image to GitHub Packages.
   # See also https://docs.docker.com/docker-hub/builds/
   push:
-    # Ensure test job passes before pushing image.
-    needs: test
-
     runs-on: ubuntu-latest
     if: github.event_name == 'push'
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM registry.access.redhat.com/ubi8/ubi-minimal
 
 RUN microdnf install -y python38 git && \
+  rm -rf /var/cache/microdnf && \
   mkdir /app
 
 COPY . /app/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM registry.access.redhat.com/ubi8/ubi-minimal
+
+RUN microdnf install -y python38 git && \
+  mkdir /app
+
+COPY . /app/
+
+WORKDIR /app
+
+RUN python3 -m pip install -r requirements.txt
+
+# Pass parameters to the container run or mount your config.json into /app/
+ENTRYPOINT [ "python3", "pycryptobot.py" ]

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Docker](https://github.com/whittlem/pycryptobot/actions/workflows/docker-publish.yml/badge.svg)](https://github.com/whittlem/pycryptobot/actions/workflows/docker-publish.yml)
+
 # Python Crypto Bot v2.0.0 (pycryptobot)
 
 ## What's New?
@@ -7,6 +9,7 @@
 * Added "smart switching" between 15 minute and 1 hour graphs
 * Added additional technical indicators and candlesticks
 * Improved visual graphs for analysis
+* The bot is now also packaged in a container image
 
 ## Introduction
 
@@ -23,31 +26,45 @@ if running multiple bots and keeping track of their progress.
 
 ## Prerequisites
 
+* When running in containers: a working docker/podman installation
+
 * Python 3.9.x installed -- https://installpython3.com  (must be Python 3.9 or greater)
 
     % python3 --version
-    
+
     Python 3.9.1
-    
+
 * Python 3 PIP installed -- https://pip.pypa.io/en/stable/installing
 
     % python3 -m pip --version
-    
+
     pip 21.0.1 from /usr/local/lib/python3.9/site-packages/pip (python 3.9)
 
 ## Installation
 
-    git clone https://github.com/whittlem/pycryptobot
-    cd pycryptobot
-    python3 -m pip install -r requirements.txt
+### Manual
+
+    % git clone https://github.com/whittlem/pycryptobot
+    % cd pycryptobot
+    % python3 -m pip install -r requirements.txt
+
+### Container
+
+    % docker pull ghcr.io/whittlem/pycryptobot:latest
 
 ## Additional Information
 
-The "requirements.txt" was created with "python3 -m pip freeze"
+The "requirements.txt" was created with `python3 -m pip freeze`
 
 ## Run it
 
-% python3 pycryptobot.py <arguments>
+Manual:
+
+    % python3 pycryptobot.py <arguments>
+
+Container:
+
+    % docker run -d -v ./config.json:/app/config.json ghcr.io/whittlem/pycryptobot:latest <arguments>
 
     * Arguments
     --exchange <exchange> (coinbasepro or binance)
@@ -73,35 +90,39 @@ The "requirements.txt" was created with "python3 -m pip freeze"
 
 Typically I would save all my settings in the config.json but running from the command line I would usually run it like this.
 
-% python3 pycryptobot.py --market BTC-GBP --granularity 3600 --live 1 --verbose 0 --selllowerpcnt -2
+    % python3 pycryptobot.py --market BTC-GBP --granularity 3600 --live 1 --verbose 0 --selllowerpcnt -2
 
 ## Bot mechanics
 
 Smart switching:
-    * If the EMA12 is greater than the EMA26 on the 1 hour and 6 hour intervals switch to start trading on the 15 minute intervals
-    * If the EMA12 is lower than the EMA26 on the 1 hour and 6 hour intervals switch back to trade on the 1 hour intervals
-    * If a "granularity" is specified as an argument or in the config.json then smart switching will be disabled
-    * Force smart switching between 1 hour and 15 minute intervals with "smartswitch" argument or config option (1 or 0)
+
+* If the EMA12 is greater than the EMA26 on the 1 hour and 6 hour intervals switch to start trading on the 15 minute intervals
+* If the EMA12 is lower than the EMA26 on the 1 hour and 6 hour intervals switch back to trade on the 1 hour intervals
+* If a "granularity" is specified as an argument or in the config.json then smart switching will be disabled
+* Force smart switching between 1 hour and 15 minute intervals with "smartswitch" argument or config option (1 or 0)
 
 Buy signal:
-    * EMA12 is currently crossing above the EMA26
-    * MACD is above the Signal
-    * Golden Cross (SMA50 is above the SMA200) <-- bull market detection
-    * Elder Ray Buy is True <-- bull market detection
+
+* EMA12 is currently crossing above the EMA26
+* MACD is above the Signal
+* Golden Cross (SMA50 is above the SMA200) <-- bull market detection
+* Elder Ray Buy is True <-- bull market detection
 
 The bot will only trade in a bull market to minimise losses!
 
 Sell signal:
-    * EMA12 is currently crossing below the EMA26
-    * MACD is below the Signal
+
+* EMA12 is currently crossing below the EMA26
+* MACD is below the Signal
 
 Special sell cases:
-    * If "sellatloss" is on, bot will sell if price drops below the lower Fibonacci band
-    * If "sellatloss" is on and "selllowerpcnt" is specified the bot will sell at the specified amount E.g. -2 for -2% margin
-    * If "sellupperpcnt" is specified the bot will sell at the specified amount E.g. 10 for 10% margin (Depending on the conditions I lock in profit at 3%)
-    * If the margin exceeds 3% and the price reaches a Fibonacci band it will sell to lock in profit
-    * If the margin exceeds 3% but a strong reversal is detected with negative OBV and MACD < Signal it will sell
-    * "sellatloss" set to 0 prevents selling at a loss
+
+* If "sellatloss" is on, bot will sell if price drops below the lower Fibonacci band
+* If "sellatloss" is on and "selllowerpcnt" is specified the bot will sell at the specified amount E.g. -2 for -2% margin
+* If "sellupperpcnt" is specified the bot will sell at the specified amount E.g. 10 for 10% margin (Depending on the conditions I lock in profit at 3%)
+* If the margin exceeds 3% and the price reaches a Fibonacci band it will sell to lock in profit
+* If the margin exceeds 3% but a strong reversal is detected with negative OBV and MACD < Signal it will sell
+* "sellatloss" set to 0 prevents selling at a loss
 
 ## "Sell At Loss" explained
 
@@ -158,7 +179,7 @@ Coinbase Pro only (new format)
                 "granularity" : "3600",
                 "live" : 0,
                 "verbose" : 0
-            }    
+            }
         }
     }
 
@@ -175,7 +196,7 @@ Binance only (new format)
                 "granularity" : "1h",
                 "live" : 0,
                 "verbose" : 0
-            }        
+            }
         }
     }
 
@@ -192,7 +213,7 @@ Coinbase Pro and Binance (new format)
                 "granularity" : "1h",
                 "live" : 0,
                 "verbose" : 0
-            }        
+            }
         },
         "coinbasepro" : {
             "api_url" : "https://api.pro.coinbase.com",
@@ -205,13 +226,22 @@ Coinbase Pro and Binance (new format)
                 "granularity" : "3600",
                 "live" : 0,
                 "verbose" : 0
-            }    
+            }
         }
     }
 
 All the "config" options in the config.json can be passed as arguments E.g. --market <market>
-    
-Command line arguments override config.json config. 
+
+Command line arguments override config.json config.
+
+For telegram, add a piece to the config.json as follows:
+
+    "telegram" : {
+        "token" : "<token>",
+        "client_id" : "<client id>"
+    }
+
+You can use @botfather and @myidbot in telegram to create a bot with token and get a client id.
 
 ## Multi-Market Trading
 
@@ -241,11 +271,11 @@ The way I run my five bots is as follow:
     BTC-GBP % rm pycryptobot.log; git pull; clear; python3 pycryptobot.py
 
     BCH-GBP % rm pycryptobot.log; git pull; clear; python3 pycryptobot.py
-    
+
     ETH-GBP % rm pycryptobot.log; git pull; clear; python3 pycryptobot.py
-    
+
     LTC-GBP % rm pycryptobot.log; git pull; clear; python3 pycryptobot.py
-    
+
     XLM-EUR % rm pycryptobot.log; git pull; clear; python3 pycryptobot.py
 
 Notice how I don't pass any arguments. It's all retrieved from the config.json but you can pass the arguments manually as well.
@@ -266,13 +296,13 @@ Please note you need to be using Python 3.9.x or greater. The previous bot versi
 I push updates regularly and it's best to always be running the latest code. In each bot directory make sure you run this regularly.
 
     git pull
-    
+
 I've actually included this in the examples in how to start the bot that will do this for you automatically.
 
 ## Fun quick non-live demo
 
     python3 pycryptobot.py --market BTC-GBP --granularity 3600 --sim fast --verbose 0
-    
+
 If you get stuck with anything email me or raise an issue in the repo and I'll help you sort it out. Raising an issue is probably better as the question and response may help others.
-    
+
 Enjoy and happy trading! :)

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ if running multiple bots and keeping track of their progress.
 
 ### Container
 
-    % docker pull ghcr.io/whittlem/pycryptobot:latest
+    % docker pull ghcr.io/whittlem/pycryptobot/pycryptobot:latest
 
 ## Additional Information
 
@@ -64,7 +64,7 @@ Manual:
 
 Container:
 
-    % docker run -d -v ./config.json:/app/config.json ghcr.io/whittlem/pycryptobot:latest <arguments>
+    % docker run -d -v ./config.json:/app/config.json ghcr.io/whittlem/pycryptobot/pycryptobot:latest <arguments>
 
     * Arguments
     --exchange <exchange> (coinbasepro or binance)

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -2,7 +2,7 @@ version: "3"
 
 services:
   pycryptobot:
-    image: ghcr.io/whittlem/pycryptobot:latest
+    image: ghcr.io/whittlem/pycryptobot/pycryptobot:latest
     container_name: pycryptobot
     volumes:
       - ./config.json:/app/config.json

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,28 @@
+version: "3"
+
+services:
+  pycryptobot:
+    image: ghcr.io/whittlem/pycryptobot:latest
+    container_name: pycryptobot
+    volumes:
+      - ./config.json:/app/config.json
+      - ./graphs:/app/graphs
+      - /etc/localtime:/etc/localtime:ro
+#
+# You can also run multiple containers for each trading pair:
+#
+#  pycryptobot_btceur:
+#    image: ghcr.io/whittlem/pycryptobot:latest
+#    container_name: pycryptobot
+#    volumes:
+#      - ./config_btceur.json:/app/config.json
+#      - ./graphs:/app/graphs
+#      - /etc/localtime:/etc/localtime:ro
+#
+#  pycryptobot_etheur:
+#    image: ghcr.io/whittlem/pycryptobot:latest
+#    container_name: pycryptobot
+#    volumes:
+#      - ./config_etheur.json:/app/config.json
+#      - ./graphs:/app/graphs
+#      - /etc/localtime:/etc/localtime:ro


### PR DESCRIPTION
This PR adds a Dockerfile and example docker-compose.yaml to allow for easier administration. 

In order to enable the build in your repo, you should:

* create a PAT for your account (User > Settings > Developer settings > Personal Access Tokens) with the read and write package rights
* put the token into a secret variable for this repo (Settings > secrets > New secret). Give it the name "PACKAGE_TOKEN" as this is configured in the github action
* Change the visibility of the created "package" (User > Your Profile > Packages > pycryptobot/pycryptobot > Package settings > Change visibility

It is a bit of work, but it makes usability a lot easier :) 

I also fixed all markdown-lint violations in the readme file.

You can check the actual container that was built out of this: ghcr.io/lvlie/pycryptobot/pycryptobot:latest

And I think the "action" log should also be visible as well: https://github.com/lvlie/pycryptobot/runs/2307818414?check_suite_focus=true