### PR TITLE
Manage new markets

### DIFF
--- a/models/Binance.py
+++ b/models/Binance.py
@@ -5,7 +5,12 @@ import pandas as pd
 from datetime import datetime, timedelta
 from binance.client import Client
 
-class AuthAPI():
+class AuthAPIBase():
+    def _isMarketValid(self, market):
+        p = re.compile(r"^[A-Z]{6,12}$")
+        return p.match(market)
+
+class AuthAPI(AuthAPIBase):
     def __init__(self, api_key='', api_secret='', api_url='https://api.binance.com'):
         """Binance API object model
     
@@ -64,8 +69,7 @@ class AuthAPI():
         """Executes a market buy providing a funding amount"""
 
         # validates the market is syntactically correct
-        p = re.compile(r"^[A-Z]{6,12}$")
-        if not p.match(market):
+        if not self._isMarketValid(market):
             raise ValueError('Binanace market is invalid.')
 
         # validates quote_quantity is either an integer or float
@@ -97,8 +101,7 @@ class AuthAPI():
         """Executes a market sell providing a crypto amount"""
 
         # validates the market is syntactically correct
-        p = re.compile(r"^[A-Z]{6,12}$")
-        if not p.match(market):
+        if not self._isMarketValid(market):
             raise ValueError('Binanace market is invalid.')
 
         if not isinstance(base_quantity, int) and not isinstance(base_quantity, float):
@@ -124,8 +127,7 @@ class AuthAPI():
 
     def getMarketInfo(self, market):
         # validates the market is syntactically correct
-        p = re.compile(r"^[A-Z]{6,12}$")
-        if not p.match(market):
+        if not self._isMarketValid(market):
             raise TypeError('Binance market required.')
 
         return self.client.get_symbol_info(symbol=market)
@@ -135,8 +137,7 @@ class AuthAPI():
 
     def getTicker(self, market):
         # validates the market is syntactically correct
-        p = re.compile(r"^[A-Z]{6,12}$")
-        if not p.match(market):
+        if not self._isMarketValid(market):
             raise TypeError('Binance market required.')
 
         resp = self.client.get_symbol_ticker(symbol=market)
@@ -153,7 +154,7 @@ class AuthAPI():
         epoch = int(str(resp['serverTime'])[0:10])
         return datetime.fromtimestamp(epoch)
 
-class PublicAPI():
+class PublicAPI(AuthAPIBase):
     def __init__(self):
         self.client = Client()
 
@@ -165,8 +166,7 @@ class PublicAPI():
 
     def getHistoricalData(self, market='BTCGBP', granularity='1h', iso8601start='', iso8601end=''):
         # validates the market is syntactically correct
-        p = re.compile(r"^[A-Z]{6,12}$")
-        if not p.match(market):
+        if not self._isMarketValid(market):
             raise TypeError('Binance market required.')
 
         # validates granularity is a string
@@ -282,8 +282,7 @@ class PublicAPI():
 
     def getTicker(self, market):
         # validates the market is syntactically correct
-        p = re.compile(r"^[A-Z]{6,12}$")
-        if not p.match(market):
+        if not self._isMarketValid(market):
             raise TypeError('Binance market required.')
 
         resp = self.client.get_symbol_ticker(symbol=market)

--- a/models/Binance.py
+++ b/models/Binance.py
@@ -70,7 +70,7 @@ class AuthAPI(AuthAPIBase):
 
         # validates the market is syntactically correct
         if not self._isMarketValid(market):
-            raise ValueError('Binanace market is invalid.')
+            raise ValueError('Binance market is invalid.')
 
         # validates quote_quantity is either an integer or float
         if not isinstance(quote_quantity, int) and not isinstance(quote_quantity, float):
@@ -102,7 +102,7 @@ class AuthAPI(AuthAPIBase):
 
         # validates the market is syntactically correct
         if not self._isMarketValid(market):
-            raise ValueError('Binanace market is invalid.')
+            raise ValueError('Binance market is invalid.')
 
         if not isinstance(base_quantity, int) and not isinstance(base_quantity, float):
             raise TypeError('The crypto amount is not numeric.')

--- a/models/CoinbasePro.py
+++ b/models/CoinbasePro.py
@@ -8,7 +8,12 @@ from requests.auth import AuthBase
 # production: disable traceback
 sys.tracebacklimit = 0
 
-class AuthAPI():
+class AuthAPIBase():
+    def _isMarketValid(self, market):
+        p = re.compile(r"^[1-9A-Z]{2,5}\-[1-9A-Z]{2,5}$")
+        return p.match(market)
+
+class AuthAPI(AuthAPIBase):
     def __init__(self, api_key='', api_secret='', api_pass='', api_url='https://api.pro.coinbase.com'):
         """Coinbase Pro API object model
     
@@ -142,8 +147,7 @@ class AuthAPI():
         # if market provided
         if market != '':
             # validates the market is syntactically correct
-            p = re.compile(r"^[A-Z]{3,4}\-[A-Z]{3,4}$")
-            if not p.match(market):
+            if not self._isMarketValid(market):
                 raise ValueError('Coinbase Pro market is invalid.')
 
         # if action provided
@@ -222,8 +226,7 @@ class AuthAPI():
         """Executes a market buy providing a funding amount"""
 
         # validates the market is syntactically correct
-        p = re.compile(r"^[A-Z]{3,4}\-[A-Z]{3,4}$")
-        if not p.match(market):
+        if not self._isMarketValid(market):
             raise ValueError('Coinbase Pro market is invalid.')
 
         # validates quote_quantity is either an integer or float
@@ -251,8 +254,7 @@ class AuthAPI():
         return model.authAPI('POST', 'orders', order)
 
     def marketSell(self, market='', base_quantity=0):
-        p = re.compile(r"^[A-Z]{3,4}\-[A-Z]{3,4}$")
-        if not p.match(market):
+        if not self._isMarketValid(market):
             raise ValueError('Coinbase Pro market is invalid.')
 
         if not isinstance(base_quantity, int) and not isinstance(base_quantity, float):
@@ -271,8 +273,7 @@ class AuthAPI():
         return model.authAPI('POST', 'orders', order)
 
     def limitSell(self, market='', base_quantity=0, futurePrice=0):
-        p = re.compile(r"^[A-Z]{3,4}\-[A-Z]{3,4}$")
-        if not p.match(market):
+        if not self._isMarketValid(market):
             raise ValueError('Coinbase Pro market is invalid.')
 
         if not isinstance(base_quantity, int) and not isinstance(base_quantity, float):
@@ -295,8 +296,7 @@ class AuthAPI():
         return model.authAPI('POST', 'orders', order)
 
     def cancelOrders(self, market=''):
-        p = re.compile(r"^[A-Z]{3,4}\-[A-Z]{3,4}$")
-        if not p.match(market):
+        if not self._isMarketValid(market):
             raise ValueError('Coinbase Pro market is invalid.')
 
         model = AuthAPI(self.api_key, self.api_secret, self.api_pass, self.api_url)
@@ -379,7 +379,7 @@ class AuthAPI():
                     print ('Timeout: ' + self.api_url)
                     return pd.DataFrame()
 
-class PublicAPI():
+class PublicAPI(AuthAPIBase):
     def __init__(self):
         # options
         self.debug = False
@@ -389,8 +389,7 @@ class PublicAPI():
 
     def getHistoricalData(self, market='BTC-GBP', granularity=86400, iso8601start='', iso8601end=''):
         # validates the market is syntactically correct
-        p = re.compile(r"^[A-Z]{3,4}\-[A-Z]{3,4}$")
-        if not p.match(market):
+        if not self._isMarketValid(market):
             raise TypeError('Coinbase Pro market required.')
 
         # validates granularity is an integer
@@ -472,8 +471,7 @@ class PublicAPI():
 
     def getTicker(self, market='BTC-GBP'):
        # validates the market is syntactically correct
-        p = re.compile(r"^[A-Z]{3,4}\-[A-Z]{3,4}$")
-        if not p.match(market):
+        if not self._isMarketValid(market):
             raise TypeError('Coinbase Pro market required.')
 
         resp = self.authAPI('GET','products/' + market + '/ticker')

--- a/models/PyCryptoBot.py
+++ b/models/PyCryptoBot.py
@@ -101,32 +101,27 @@ class PyCryptoBot():
                         config = config['config']
 
                         if 'base_currency' in config:
-                            p = re.compile(r"^[A-Z]{3,5}$")
-                            if not p.match(config['base_currency']):
+                            if not self._isCurrencyValid(config['base_currency']):
                                 raise TypeError('Base currency is invalid.')
                             self.base_currency = config['base_currency']
 
                         if 'cryptoMarket' in config:
-                            p = re.compile(r"^[A-Z]{3,5}$")
-                            if not p.match(config['cryptoMarket']):
+                            if not self._isCurrencyValid(config['cryptoMarket']):
                                 raise TypeError('Base currency is invalid.')
                             self.base_currency = config['cryptoMarket']
 
                         if 'quote_currency' in config:
-                            p = re.compile(r"^[A-Z]{3,5}$")
-                            if not p.match(config['quote_currency']):
+                            if not self._isCurrencyValid(config['quote_currency']):
                                 raise TypeError('Quote currency is invalid.')
                             self.quote_currency = config['quote_currency']
 
                         if 'fiatMarket' in config:
-                            p = re.compile(r"^[A-Z]{3,5}$")
-                            if not p.match(config['fiatMarket']):
+                            if not self._isCurrencyValid(config['fiatMarket']):
                                 raise TypeError('Quote currency is invalid.')
                             self.quote_currency = config['fiatMarket']
 
                         if 'market' in config:
-                            p = re.compile(r"^[A-Z]{3,5}\-[A-Z]{3,5}$")
-                            if not p.match(config['market']):
+                            if not self._isMarketValid(config['market']):
                                 raise TypeError('Market is invalid.')
 
                             self.base_currency, self.quote_currency = config['market'].split('-',  2)
@@ -212,14 +207,12 @@ class PyCryptoBot():
                         config = config['binance']['config']
 
                         if 'base_currency' in config:
-                            p = re.compile(r"^[A-Z]{3,5}$")
-                            if not p.match(config['base_currency']):
+                            if not self._isCurrencyValid(config['base_currency']):
                                 raise TypeError('Base currency is invalid.')
                             self.base_currency = config['base_currency']
 
                         if 'quote_currency' in config:
-                            p = re.compile(r"^[A-Z]{3,5}$")
-                            if not p.match(config['quote_currency']):
+                            if not self._isCurrencyValid(config['base_currency']):
                                 raise TypeError('Quote currency is invalid.')
                             self.quote_currency = config['quote_currency']
 
@@ -302,20 +295,17 @@ class PyCryptoBot():
                             config = config['coinbasepro']['config']
 
                             if 'base_currency' in config:
-                                p = re.compile(r"^[A-Z]{3,5}$")
-                                if not p.match(config['base_currency']):
+                                if not self._isCurrencyValid(config['base_currency']):
                                     raise TypeError('Base currency is invalid.')
                                 self.base_currency = config['base_currency']
 
                             if 'quote_currency' in config:
-                                p = re.compile(r"^[A-Z]{3,5}$")
-                                if not p.match(config['quote_currency']):
+                                if not self._isCurrencyValid(config['quote_currency']):
                                     raise TypeError('Quote currency is invalid.')
                                 self.quote_currency = config['quote_currency']
 
                             if 'market' in config:
-                                p = re.compile(r"^[A-Z]{3,5}\-[A-Z]{3,5}$")
-                                if not p.match(config['market']):
+                                if not self._isMarketValid(config['market']):
                                     raise TypeError('Market is invalid.')
 
                                 self.base_currency, self.quote_currency = config['market'].split('-',  2)
@@ -402,14 +392,12 @@ class PyCryptoBot():
                             config = config['binance']['config']
 
                             if 'base_currency' in config:
-                                p = re.compile(r"^[A-Z]{3,5}$")
-                                if not p.match(config['base_currency']):
+                                if not self._isCurrencyValid(config['base_currency']):
                                     raise TypeError('Base currency is invalid.')
                                 self.base_currency = config['base_currency']
 
                             if 'quote_currency' in config:
-                                p = re.compile(r"^[A-Z]{3,5}$")
-                                if not p.match(config['quote_currency']):
+                                if not self._isCurrencyValid(config['quote_currency']):
                                     raise TypeError('Quote currency is invalid.')
                                 self.quote_currency = config['quote_currency']
 
@@ -490,15 +478,13 @@ class PyCryptoBot():
 
         if args.market != None:
             if self.exchange == 'coinbasepro':
-                p = re.compile(r"^[A-Z]{3,5}\-[A-Z]{3,5}$")
-                if not p.match(args.market):
+                if not self._isMarketValid(args.market):
                     raise ValueError('Coinbase Pro market required.')
 
                 self.market = args.market
                 self.base_currency, self.quote_currency = args.market.split('-',  2)
             elif self.exchange == 'binance':
-                p = re.compile(r"^[A-Z]{6,12}$")
-                if not p.match(args.market):
+                if not self._isMarketValid(args.market):
                     raise ValueError('Binance market required.')
 
                 self.market = args.market
@@ -704,6 +690,23 @@ class PyCryptoBot():
             p = re.compile(r"^[a-z0-9]{10,11}$")
             if not p.match(self.api_passphrase):
                 raise TypeError('Coinbase Pro API passphrase is invalid')
+
+    def _isCurrencyValid(self, currency):
+        if self.exchange == 'coinbasepro' or self.exchange == 'binance':
+            p = re.compile(r"^[1-9A-Z]{2,5}$")
+            return p.match(currency)
+
+        return False
+
+    def _isMarketValid(self, market):
+        if self.exchange == 'coinbasepro':
+            p = re.compile(r"^[1-9A-Z]{2,5}\-[1-9A-Z]{2,5}$")
+            return p.match(market)
+        elif self.exchange == 'binance':
+            p = re.compile(r"^[A-Z]{6,12}$")
+            return p.match(market)
+
+        return False
 
     def getExchange(self):
         return self.exchange

--- a/models/TradingAccount.py
+++ b/models/TradingAccount.py
@@ -50,6 +50,23 @@ class TradingAccount():
         else:
             return val
 
+    def _checkMarketSyntax(self, market):
+        """Check that the market is syntactically correct
+
+        Parameters
+        ----------
+        market : str
+            market to check
+        """
+        if self.app.getExchange() == 'coinbasepro' and market != '':
+            p = re.compile(r"^[1-9A-Z]{2,5}\-[1-9A-Z]{2,5}$")
+            if not p.match(market):
+                raise TypeError('Coinbase Pro market is invalid.')
+        elif self.app.getExchange() == 'binance':
+            p = re.compile(r"^[A-Z]{6,12}$")
+            if not p.match(market):
+                raise TypeError('Binance market is invalid.')
+
     def getOrders(self, market='', action='', status='all'):
         """Retrieves orders either live or simulation
 
@@ -63,16 +80,8 @@ class TradingAccount():
             Filters orders by status, defaults to 'all'
         """
 
-        if self.app.getExchange() == 'coinbasepro' and market != '':
-            # validate market is syntactically correct
-            p = re.compile(r"^[A-Z]{3,4}\-[A-Z]{3,4}$")
-            if not p.match(market):
-                raise TypeError('Coinbase Pro market is invalid.')
-        elif self.app.getExchange() == 'binance':
-             # validate market is syntactically correct
-            p = re.compile(r"^[A-Z]{6,12}$")
-            if not p.match(market):
-                raise TypeError('Binance market is invalid.')
+        # validate market is syntactically correct
+        self._checkMarketSyntax(market)
 
         if action != '':
             # validate action is either a buy or sell
@@ -275,16 +284,8 @@ class TradingAccount():
             Output CSV file
         """
 
-        if self.app.getExchange() == 'coinbasepro' and market != '':
-            # validate market is syntactically correct
-            p = re.compile(r"^[A-Z]{3,4}\-[A-Z]{3,4}$")
-            if not p.match(market):
-                raise TypeError('Coinbase Pro market is invalid.')
-        elif self.app.getExchange() == 'binance':
-             # validate market is syntactically correct
-            p = re.compile(r"^[A-Z]{6,12}$")
-            if not p.match(market):
-                raise TypeError('Binance market is invalid.')
+        # validate market is syntactically correct
+        self._checkMarketSyntax(market)
 
         if self.mode == 'live':
             if self.app.getExchange() == 'coinbasepro':


### PR DESCRIPTION
Hi Mike,

I was changing the regexp to manage new markets. 

On CoinbasePro for example, these markets are now managed:

- 1INCH-USD
- 1INCH-EUR
- 1INCH-GBP
- 1INCH-BTC
- NU-USD
- NU-EUR
- NU-GBP
- NU-BTC
- STORJ-USD
- STORJ-BTC
- MATIC-USD
- MATIC-GBP
- MATIC-EUR
- MATIC-BTC
- SUSHI-USD
- SUSHI-EUR
- SUSHI-GBP
- SUSHI-BTC
- SUSHI-ETH

I also did some refactoring to avoid duplicating the regexp many times.

Kind regards

