### PR TITLE
fixes issue #178

### DIFF
--- a/models/config/coinbase_pro_parser.py
+++ b/models/config/coinbase_pro_parser.py
@@ -80,7 +80,7 @@ def parser(app, coinbase_config, args = {}):
 
         if 'granularity' in config and config['granularity'] != None:
             if config['granularity'].isnumeric() is True:
-                config['granularity'] = int(config['granularity'].isnumeric())
+                config['granularity'] = int(config['granularity'])
 
             if isinstance(config['granularity'], int):
                 if config['granularity'] in [60, 300, 900, 3600, 21600, 86400]:

--- a/models/config/coinbase_pro_parser.py
+++ b/models/config/coinbase_pro_parser.py
@@ -78,11 +78,16 @@ def parser(app, coinbase_config, args = {}):
         if app.base_currency != '' and app.quote_currency != '':
             app.market = app.base_currency + '-' + app.quote_currency
 
-        if 'granularity' in config and config['granularity'] != None:
-            if config['granularity'].isnumeric() is True:
-                config['granularity'] = int(config['granularity'])
+        if 'granularity' in config and config['granularity'] != None:        
+            if isinstance(config['granularity'], str):
+                if config['granularity'].isnumeric() is True:
+                    config['granularity'] = int(config['granularity'])
 
-            if isinstance(config['granularity'], int):
+                if config['granularity'] in [60, 300, 900, 3600, 21600, 86400]:
+                    app.granularity = config['granularity']
+                    app.smart_switch = 0
+
+            elif isinstance(config['granularity'], int):
                 if config['granularity'] in [60, 300, 900, 3600, 21600, 86400]:
                     app.granularity = config['granularity']
                     app.smart_switch = 0

--- a/models/config/coinbase_pro_parser.py
+++ b/models/config/coinbase_pro_parser.py
@@ -78,19 +78,17 @@ def parser(app, coinbase_config, args = {}):
         if app.base_currency != '' and app.quote_currency != '':
             app.market = app.base_currency + '-' + app.quote_currency
 
-        if 'granularity' in config and config['granularity'] != None:        
-            if isinstance(config['granularity'], str):
-                if config['granularity'].isnumeric() is True:
-                    config['granularity'] = int(config['granularity'])
-
-                if config['granularity'] in [60, 300, 900, 3600, 21600, 86400]:
-                    app.granularity = config['granularity']
-                    app.smart_switch = 0
-
+        if 'granularity' in config and config['granularity'] != None:
+            granularity = 0
+            if isinstance(config['granularity'], str) and config['granularity'].isnumeric() is True:
+                granularity = int(config['granularity'])
             elif isinstance(config['granularity'], int):
-                if config['granularity'] in [60, 300, 900, 3600, 21600, 86400]:
-                    app.granularity = config['granularity']
-                    app.smart_switch = 0
+                granularity = config['granularity']
+
+            if granularity in [60, 300, 900, 3600, 21600, 86400]:
+                app.granularity = config['granularity']
+                app.smart_switch = 0
+
 
     else:
         raise Exception('There is an error in your config dictionnary')


### PR DESCRIPTION
## Description

Make sure the granularity is not overwritten to 1, resulting in the default value (3600) always being used.

Fixes #178 

## Type of change

Please make your selection.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This change requires a new dependency
- [ ] Code Maintainability / comments
- [ ] Code Refactoring / future-proofing

## How Has This Been Tested?

Tested with different values for granularity (integers and non-integers). Granularity tested by setting it in the config.json and as an argument.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added pytest unit tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
