### PR TITLE
Fixed marketBaseIncrement for zero ndigits

### DIFF
--- a/models/exchange/coinbase_pro/api.py
+++ b/models/exchange/coinbase_pro/api.py
@@ -12,6 +12,7 @@ import pandas as pd
 from datetime import datetime, timedelta
 from requests.auth import AuthBase
 from requests import Request
+from math import floor
 
 # Constants
 
@@ -355,7 +356,6 @@ class AuthAPI(AuthAPIBase):
         else:
             nb_digits = 0
 
-        from math import floor
         return floor(amount * 10 ** nb_digits) / 10 ** nb_digits
 
     def authAPI(self, method: str, uri: str, payload: str='') -> pd.DataFrame:

--- a/models/exchange/coinbase_pro/api.py
+++ b/models/exchange/coinbase_pro/api.py
@@ -355,7 +355,8 @@ class AuthAPI(AuthAPIBase):
         else:
             nb_digits = 0
 
-        return float(f'%.{nb_digits}f'%(amount))
+        from math import floor
+        return floor(amount * 10 ** nb_digits) / 10 ** nb_digits
 
     def authAPI(self, method: str, uri: str, payload: str='') -> pd.DataFrame:
         if not isinstance(method, str):


### PR DESCRIPTION
## Description

The function marketBaseIncrement for base increments of 1, like in XLM case, were rounding up, making that a bigger value than the funds available was returned.

This should fix the "Insufficient funds" errors and the "size is too accurate" errors, the later one indirectly since the bought value would no longer different than the base increment.

Solution based on a comment by @horamarques in issue #185.

Fixes #185 and #187

## Type of change

Please make your selection.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This change requires a new dependency
- [ ] Code Maintainability / comments
- [ ] Code Refactoring / future-proofing

## How Has This Been Tested?

Run the function with different amounts and base increments.

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added pytest unit tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings
