### PR TITLE
Fix issue #200 1INCH ticker is not recognized

### DIFF
--- a/models/config/binance_parser.py
+++ b/models/config/binance_parser.py
@@ -5,7 +5,7 @@ from .default_parser import isCurrencyValid, defaultConfigParse, merge_config_an
 def isMarketValid(market):
     if market == None:
         return False
-    p = re.compile(r"^[A-Z]{6,12}$")
+    p = re.compile(r"^[0-9A-Z]{6,12}$")
     return p.match(market)
 
 def parseMarket(market):


### PR DESCRIPTION
## Description

Currently  1INCHUSDT is not recognized on Binance as a valid market.

Fixes #200 

## Type of change

Please make your selection.

- [ x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This change requires a new dependency
- [ ] Code Maintainability / comments
- [ ] Code Refactoring / future-proofing
