### PR TITLE
Correction for "Size is too accurate" problem

### DIFF
--- a/models/exchange/coinbase_pro/api.py
+++ b/models/exchange/coinbase_pro/api.py
@@ -282,7 +282,7 @@ class AuthAPI(AuthAPIBase):
             'product_id': market,
             'type': 'market',
             'side': 'buy',
-            'funds': self.marketBaseIncrement(market, quote_quantity)
+            'funds': self.marketQuoteIncrement(market, quote_quantity)
         }
 
         if self.debug is True:
@@ -305,7 +305,7 @@ class AuthAPI(AuthAPIBase):
             'product_id': market,
             'type': 'market',
             'side': 'sell',
-            'size': base_quantity
+            'size': self.marketBaseIncrement(market, base_quantity)
         }
 
         print (order)
@@ -327,7 +327,7 @@ class AuthAPI(AuthAPIBase):
             'product_id': market,
             'type': 'limit',
             'side': 'sell',
-            'size': base_quantity,
+            'size': self.marketBaseIncrement(market, base_quantity),
             'price': futurePrice
         }
 
@@ -353,6 +353,21 @@ class AuthAPI(AuthAPIBase):
 
         if '.' in str(base_increment):
             nb_digits = len(str(base_increment).split('.')[1])
+        else:
+            nb_digits = 0
+
+        return floor(amount * 10 ** nb_digits) / 10 ** nb_digits
+
+    def marketQuoteIncrement(self, market, amount) -> float:
+        product = self.authAPI('GET', f'products/{market}')
+
+        if 'quote_increment' not in product:
+            return amount
+
+        quote_increment = str(product['quote_increment'].values[0])
+
+        if '.' in str(quote_increment):
+            nb_digits = len(str(quote_increment).split('.')[1])
         else:
             nb_digits = 0
 


### PR DESCRIPTION
## Description

[Coinbase Pro] Size is too accurate (buy and sell: quote_increment vs base_increment) fix

Fixes #201 and #216 

## Type of change

Please make your selection.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This change requires a new dependency
- [ ] Code Maintainability / comments
- [ ] Code Refactoring / future-proofing

## How Has This Been Tested?

print(api.marketBaseIncrement("BTC-EUR", 50.1234567890)) #  50.123456789
print(api.marketQuoteIncrement("BTC-EUR", 50.1234567890)) # 50.12

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added pytest unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
