### PR TITLE
Fix margin calculation.

### DIFF
--- a/models/exchange/binance/api.py
+++ b/models/exchange/binance/api.py
@@ -172,7 +172,7 @@ class AuthAPI(AuthAPIBase):
             return pd.DataFrame()
 
         df = df[[ 'time', 'symbol', 'side', 'type', 'executedQty', 'cummulativeQuoteQty', 'status' ]]
-        df.columns = [ 'created_at', 'market', 'action', 'type', 'size', 'filled', 'status' ]
+        df.columns = [ 'created_at', 'market', 'action', 'type', 'filled', 'size', 'status' ]
         df['created_at'] = df['created_at'].apply(lambda x: int(str(x)[:10]))
         df['created_at'] = df['created_at'].astype("datetime64[s]")
         df['size'] = df['size'].astype(float)
@@ -180,7 +180,7 @@ class AuthAPI(AuthAPIBase):
         df['action'] = df['action'].str.lower()
         df['type'] = df['type'].str.lower()
         df['status'] = df['status'].str.lower()
-        df['price'] = df['filled'] / df['size']
+        df['price'] = df['size'] / df['filled']
 
         # pylint: disable=unused-variable
         for k, v in df.items():

--- a/models/helper/MarginHelper.py
+++ b/models/helper/MarginHelper.py
@@ -1,49 +1,31 @@
 def calculate_margin(buy_size: float = 0.0, buy_filled: int = 0.0, buy_price: int = 0.0, buy_fee: float = 0.0,
                      sell_percent: float = 100, sell_price: float = 0.0, sell_fee: float = 0.0,
-                     sell_taker_fee: float = 0.0, debug: bool = False, exchange: str = 'coinbasepro') -> float:
+                     sell_taker_fee: float = 0.0, debug: bool = False) -> float:
     
     if debug is True:
-        print(f'buy_size: {buy_size}') #buy_size for CB is quote currency, for binance is base currency
-        print(f'buy_filled: {buy_filled}') #buy_filled for CB is base currency, for binance is quote currency
-        print(f'buy_price: {buy_price}') #buy_price for CB is quote currency, for binance is quote currency
-        print(f'buy_fee: {buy_fee}', "\n") #buy_fee for CB is quote currency, for binance is quote currency
+        print(f'buy_size: {buy_size}') #buy_size is quote currency,
+        print(f'buy_filled: {buy_filled}') #buy_filled is base currency,
+        print(f'buy_price: {buy_price}') #buy_price is quote currency, 
+        print(f'buy_fee: {buy_fee}', "\n") #buy_fee is quote currency, 
 
-    #for CB buy_size represents the quote currency value of the buy including fees and buy_filled represents the base currency size of the buy
-    #for Binance buy_filled represents the quote currency value of the buy including fees and buy_size represents the base currency size of the buy
+    # buy_size represents the quote currency value of the buy including fees and buy_filled represents the base currency size of the buy
 
-    if exchange == 'coinbasepro':
-        #sell_size in quote currency by multiplying current price by buy_filled in base currency
-        sell_size = round((sell_percent / 100) * (sell_price  * buy_filled), 8)
+    #sell_size in quote currency by multiplying current price by buy_filled in base currency
+    sell_size = round((sell_percent / 100) * (sell_price  * buy_filled), 8)
 
-        #calculate sell_fee in quote currency
-        if sell_fee == 0.0 and sell_taker_fee > 0.0:
-            sell_fee = round((sell_size * sell_taker_fee), 8)
-        
-        #calculate sell_value after fees in quote currency
-        sell_value = round(sell_size - sell_fee, 8)
+    #calculate sell_fee in quote currency
+    if sell_fee == 0.0 and sell_taker_fee > 0.0:
+        sell_fee = round((sell_size * sell_taker_fee), 8)
+    
+    #calculate sell_value after fees in quote currency
+    sell_value = round(sell_size - sell_fee, 8)
 
-        #profit is difference between sell_value without fees and buy_size including fees in quote currency
-        profit = round(sell_value - buy_size, 2)
+    #profit is difference between sell_value without fees and buy_size including fees in quote currency
+    profit = round(sell_value - buy_size, 2)
 
-        #calculate margin
-        margin = round((profit / buy_size) * 100, 2)
+    #calculate margin
+    margin = round((profit / buy_size) * 100, 2)
 
-    else:
-        #sell size in quote currency by multiplying current price by buy_size in base currency
-        sell_size = round((sell_percent / 100) * (sell_price  * buy_size), 8)
-
-        #calculate sell fee in quote currency
-        if sell_fee == 0.0 and sell_taker_fee > 0.0:
-            sell_fee = round(sell_size * sell_taker_fee, 8)
-        
-        #calculate sell_value after fees in quote currency
-        sell_value = round(sell_size - sell_fee, 8)
-        
-        #profit is difference between sell_value and buy_filled in quote currency
-        profit = round(sell_value - buy_filled, 2)
-        
-        #calculate margin
-        margin = round((profit / buy_filled) * 100, 2)
          
     if debug is True:
        

--- a/tests/unit_tests/test_margin_calculation.py
+++ b/tests/unit_tests/test_margin_calculation.py
@@ -7,11 +7,10 @@ from models.helper.MarginHelper import calculate_margin
 def test_margin_binance():
     # using VET-GBP
     buy_fee = 0.07434422700000001
-    buy_filled = 74.344227
+    buy_filled = 595.23
     buy_price = 0.1249
-    buy_size = 595.23
+    buy_size = 74.344227
     debug = True
-    exchange = 'binance'
     sell_fee = 0.0
     sell_percent = 100
     sell_price = 0.1335
@@ -19,7 +18,7 @@ def test_margin_binance():
 
     actual_margin, actual_profit, actual_sell_fee = calculate_margin(buy_size, buy_filled, buy_price, buy_fee,
                                                                      sell_percent, sell_price, sell_fee, sell_taker_fee,
-                                                                     debug, exchange)
+                                                                     debug)
 
     assert actual_margin == 6.78
     assert actual_profit == 5.04
@@ -33,7 +32,6 @@ def test_margin_coinbase_pro():
     buy_price = 34.50004
     buy_size = 310.11
     debug = True
-    exchange = 'coinbasepro'
     sell_fee = 0.0
     sell_percent = 100
     sell_price = 30.66693
@@ -41,7 +39,7 @@ def test_margin_coinbase_pro():
 
     actual_margin, actual_profit, actual_sell_fee = calculate_margin(buy_size, buy_filled, buy_price, buy_fee,
                                                                      sell_percent, sell_price, sell_fee, sell_taker_fee,
-                                                                     debug, exchange)
+                                                                     debug)
 
     assert actual_margin == -11.8
     assert actual_profit == -36.6


### PR DESCRIPTION
## Description
Fix margin calculation system wide by swapping sell_size and sell_filled areas in the df dictionary.
By this we are keeping calculations clear and non exchange specific.
This also fix margin calculation problem on simulator.

Fixes # (issue)
-

## Type of change

Please make your selection.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This change requires a new dependency
- [ ] Code Maintainability / comments
- [] Code Refactoring / future-proofing

## How Has This Been Tested?
Only tested for Binance both live buy and sells and simulator.

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

## Checklist:

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added pytest unit tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
