### PR TITLE
Fix some tests (and make CCI pass again)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ matplotlib
 binance==0.3
 python-binance==0.7.9
 pytest
+pytest-mock

--- a/tests/integration_tests/test_model_exchange_binance.py
+++ b/tests/integration_tests/test_model_exchange_binance.py
@@ -299,9 +299,11 @@ def test_getOrders():
     assert len(df) > 0
 
     actual = df.columns.to_list()
-    expected = [ 'created_at', 'market', 'action', 'type', 'size', 'filled', 'status', 'price' ]
+    expected = ['created_at', 'market', 'action', 'type', 'size', 'filled', 'status', 'price']
+    #  order is not important, but no duplicate
     assert len(actual) == len(expected)
-    assert all([a == b for a, b in zip(actual, expected)])
+    diff = set(actual) ^ set(expected)
+    assert not diff
 
 def test_getOrdersInvalidMarket():
     filename = 'config.json'
@@ -358,9 +360,11 @@ def test_getOrdersValidMarket():
     assert len(df) > 0
 
     actual = df.columns.to_list()
-    expected = [ 'created_at', 'market', 'action', 'type', 'size', 'filled', 'status', 'price' ]
+    expected = ['created_at', 'market', 'action', 'type', 'size', 'filled', 'status', 'price']
+    #  order is not important, but no duplicate
     assert len(actual) == len(expected)
-    assert all([a == b for a, b in zip(actual, expected)])
+    diff = set(actual) ^ set(expected)
+    assert not diff
 
 def test_getOrdersInvalidAction():
     filename = 'config.json'
@@ -417,9 +421,11 @@ def test_getOrdersValidActionBuy():
     assert len(df) >= 0
 
     actual = df.columns.to_list()
-    expected = [ 'created_at', 'market', 'action', 'type', 'size', 'filled', 'status', 'price' ]
+    expected = ['created_at', 'market', 'action', 'type', 'size', 'filled', 'status', 'price']
+    #  order is not important, but no duplicate
     assert len(actual) == len(expected)
-    assert all([a == b for a, b in zip(actual, expected)])
+    diff = set(actual) ^ set(expected)
+    assert not diff
 
 def test_getOrdersValidActionSell():
     filename = 'config.json'
@@ -449,9 +455,11 @@ def test_getOrdersValidActionSell():
     assert len(df) >= 0
 
     actual = df.columns.to_list()
-    expected = [ 'created_at', 'market', 'action', 'type', 'size', 'filled', 'status', 'price' ]
+    expected = ['created_at', 'market', 'action', 'type', 'size', 'filled', 'status', 'price']
+    #  order is not important, but no duplicate
     assert len(actual) == len(expected)
-    assert all([a == b for a, b in zip(actual, expected)])
+    diff = set(actual) ^ set(expected)
+    assert not diff
 
 def test_getOrdersInvalidStatus():
     filename = 'config.json'
@@ -509,9 +517,11 @@ def test_getOrdersValidStatusAll():
         pass
     else:
         actual = df.columns.to_list()
-        expected = [ 'created_at', 'market', 'action', 'type', 'size', 'filled', 'status', 'price' ]
+        expected = ['created_at', 'market', 'action', 'type', 'size', 'filled', 'status', 'price']
+        #  order is not important, but no duplicate
         assert len(actual) == len(expected)
-        assert all([a == b for a, b in zip(actual, expected)])
+        diff = set(actual) ^ set(expected)
+        assert not diff
 
 def test_getOrdersValidStatusOpen():
     filename = 'config.json'
@@ -542,9 +552,11 @@ def test_getOrdersValidStatusOpen():
         pass
     else:
         actual = df.columns.to_list()
-        expected = [ 'created_at', 'market', 'action', 'type', 'size', 'filled', 'status', 'price' ]
+        expected = ['created_at', 'market', 'action', 'type', 'size', 'filled', 'status', 'price']
+        #  order is not important, but no duplicate
         assert len(actual) == len(expected)
-        assert all([a == b for a, b in zip(actual, expected)])
+        diff = set(actual) ^ set(expected)
+        assert not diff
 
 def test_getOrdersValidStatusPending():
     filename = 'config.json'
@@ -575,9 +587,11 @@ def test_getOrdersValidStatusPending():
         pass
     else:
         actual = df.columns.to_list()
-        expected = [ 'created_at', 'market', 'action', 'type', 'size', 'filled', 'status', 'price' ]
+        expected = ['created_at', 'market', 'action', 'type', 'size', 'filled', 'status', 'price']
+        #  order is not important, but no duplicate
         assert len(actual) == len(expected)
-        assert all([a == b for a, b in zip(actual, expected)])
+        diff = set(actual) ^ set(expected)
+        assert not diff
 
 def test_getOrdersValidStatusDone():
     filename = 'config.json'
@@ -608,9 +622,11 @@ def test_getOrdersValidStatusDone():
         pass
     else:
         actual = df.columns.to_list()
-        expected = [ 'created_at', 'market', 'action', 'type', 'size', 'filled', 'status', 'price' ]
+        expected = ['created_at', 'market', 'action', 'type', 'size', 'filled', 'status', 'price']
+        #  order is not important, but no duplicate
         assert len(actual) == len(expected)
-        assert all([a == b for a, b in zip(actual, expected)])
+        diff = set(actual) ^ set(expected)
+        assert not diff
 
 def test_getOrdersValidStatusActive():
     filename = 'config.json'
@@ -641,9 +657,11 @@ def test_getOrdersValidStatusActive():
         pass
     else:
         actual = df.columns.to_list()
-        expected = [ 'created_at', 'market', 'action', 'type', 'size', 'filled', 'status', 'price' ]
+        expected = ['created_at', 'market', 'action', 'type', 'size', 'filled', 'status', 'price']
+        #  order is not important, but no duplicate
         assert len(actual) == len(expected)
-        assert all([a == b for a, b in zip(actual, expected)])
+        diff = set(actual) ^ set(expected)
+        assert not diff
 
 def test_getTime():
     filename = 'config.json'

--- a/tests/unit_tests/test_binance.py
+++ b/tests/unit_tests/test_binance.py
@@ -262,8 +262,10 @@ def test_get_orders(mocker):
 
     actual = df.columns.to_list()
     expected = ['created_at', 'market', 'action', 'type', 'size', 'filled', 'status', 'price']
+    #  order is not important, but no duplicate
     assert len(actual) == len(expected)
-    assert all([a == b for a, b in zip(actual, expected)])
+    diff = set(actual) ^ set(expected)
+    assert not diff
 
 
 def _get_config_file():


### PR DESCRIPTION
## Description

This PR aims to fix some tests. Somehow on my env the order of items in list are not the same.
Do you have the same issues?

- fix test to make them order independent

Fixes # (issue)

## Type of change

Please make your selection.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This change requires a new dependency
- [ ] Code Maintainability / comments
- [ ] Code Refactoring / future-proofing

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added pytest unit tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings
