### PR TITLE
Calculate simulation trades cumulatively.

### DIFF
--- a/models/AppState.py
+++ b/models/AppState.py
@@ -20,3 +20,4 @@ class AppState():
         self.last_df_index = ''
         self.sell_count = 0
         self.sell_sum = 0
+        self.first_buy_size = 0


### PR DESCRIPTION
## Description
Calculating simulation trades cumulatively instead of resetting buy_size to 1000 after every transaction.

Fixes # (issue)
-

## Type of change

Please make your selection.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This change requires a new dependency
- [ ] Code Maintainability / comments
- [x] Code Refactoring / future-proofing

## How Has This Been Tested?
Only tested for Binance both live buy and sells and simulator.

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added pytest unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
