### PR TITLE
Refactoring Telegram notifications into one method

### DIFF
--- a/models/PyCryptoBot.py
+++ b/models/PyCryptoBot.py
@@ -427,9 +427,6 @@ class PyCryptoBot():
     def isSimulation(self) -> bool:
         return self.is_sim == 1
 
-    def isTelegramEnabled(self) -> bool:
-        return self.telegram
-
     def simuluationSpeed(self):
         return self.sim_speed
 
@@ -483,9 +480,6 @@ class PyCryptoBot():
 
     def disableProfitbankReversal(self) -> bool:
         return self.disableprofitbankreversal
-
-    def disableTelegram(self) -> bool:
-        return self.disabletelegram
 
     def disableLog(self) -> bool:
         return self.disablelog
@@ -670,7 +664,7 @@ class PyCryptoBot():
                 not self.disableProfitbankReversal()) + '  --disableprofitbankreversal'
             print('|', txt, (' ' * (75 - len(txt))), '|')
 
-            txt = '             Telegram : ' + str(not self.disableTelegram()) + '  --disabletelegram'
+            txt = '             Telegram : ' + str(not self.disabletelegram) + '  --disabletelegram'
             print('|', txt, (' ' * (75 - len(txt))), '|')
 
             txt = '                  Log : ' + str(not self.disableLog()) + '  --disablelog'
@@ -751,3 +745,16 @@ class PyCryptoBot():
                 tradingData = self.getHistoricalData(self.getMarket(), self.getGranularity())
 
             return tradingData
+
+    def notifyTelegram(self, msg: str) -> None:
+        """
+        Send a given message to preconfigured Telegram. If the telegram isn't enabled, e.g. via `--disabletelegram`,
+        this method does nothing and returns immediately.
+        """
+
+        if self.disabletelegram or not self.telegram:
+            return
+
+        assert self._chat_client is not None
+
+        self._chat_client.send(msg)

--- a/pycryptobot.py
+++ b/pycryptobot.py
@@ -230,10 +230,7 @@ def executeJob(sc, app=PyCryptoBot(), state=AppState(), trading_data=pd.DataFram
     if app.getSmartSwitch() == 1 and app.getGranularity() == 3600 and app.is1hEMA1226Bull() is True and app.is6hEMA1226Bull() is True:
         print('*** smart switch from granularity 3600 (1 hour) to 900 (15 min) ***')
 
-        # telegram
-        if not app.disableTelegram() and app.isTelegramEnabled():
-            telegram = app.getChatClient()
-            telegram.send(app.getMarket() + " smart switch from granularity 3600 (1 hour) to 900 (15 min)")
+        app.notifyTelegram(app.getMarket() + " smart switch from granularity 3600 (1 hour) to 900 (15 min)")
 
         app.setGranularity(900)
         list(map(s.cancel, s.queue))
@@ -242,10 +239,7 @@ def executeJob(sc, app=PyCryptoBot(), state=AppState(), trading_data=pd.DataFram
     if app.getSmartSwitch() == 1 and app.getGranularity() == 900 and app.is1hEMA1226Bull() is False and app.is6hEMA1226Bull() is False:
         print("*** smart switch from granularity 900 (15 min) to 3600 (1 hour) ***")
 
-        # telegram
-        if not app.disableTelegram() and app.isTelegramEnabled():
-            telegram = app.getChatClient()
-            telegram.send(app.getMarket() + " smart switch from granularity 900 (15 min) to 3600 (1 hour)")
+        app.notifyTelegram(app.getMarket() + " smart switch from granularity 900 (15 min) to 3600 (1 hour)")
 
         app.setGranularity(3600)
         list(map(s.cancel, s.queue))
@@ -356,10 +350,7 @@ def executeJob(sc, app=PyCryptoBot(), state=AppState(), trading_data=pd.DataFram
                 print(log_text, "\n")
                 logging.warning(log_text)
 
-                # telegram
-                if not app.disableTelegram() and app.isTelegramEnabled():
-                    telegram = app.getChatClient()
-                    telegram.send(app.getMarket() + ' (' + app.printGranularity() + ') ' + log_text)
+                app.notifyTelegram(app.getMarket() + ' (' + app.printGranularity() + ') ' + log_text)
 
             # loss failsafe sell at trailing_stop_loss
             if app.allowSellAtLoss() and app.trailingStopLoss() != None and change_pcnt_high < app.trailingStopLoss():
@@ -370,10 +361,7 @@ def executeJob(sc, app=PyCryptoBot(), state=AppState(), trading_data=pd.DataFram
                 print(log_text, "\n")
                 logging.warning(log_text)
 
-                # telegram
-                if not app.disableTelegram() and app.isTelegramEnabled():
-                    telegram = app.getChatClient()
-                    telegram.send(app.getMarket() + ' (' + app.printGranularity() + ') ' + log_text)
+                app.notifyTelegram(app.getMarket() + ' (' + app.printGranularity() + ') ' + log_text)
 
             # loss failsafe sell at sell_lower_pcnt
             elif app.disableFailsafeLowerPcnt() is False and app.allowSellAtLoss() and app.sellLowerPcnt() != None and margin < app.sellLowerPcnt():
@@ -384,10 +372,7 @@ def executeJob(sc, app=PyCryptoBot(), state=AppState(), trading_data=pd.DataFram
                 print(log_text, "\n")
                 logging.warning(log_text)
 
-                # telegram
-                if not app.disableTelegram() and app.isTelegramEnabled():
-                    telegram = app.getChatClient()
-                    telegram.send(app.getMarket() + ' (' + app.printGranularity() + ') ' + log_text)
+                app.notifyTelegram(app.getMarket() + ' (' + app.printGranularity() + ') ' + log_text)
 
             # profit bank at sell_upper_pcnt
             if app.disableProfitbankUpperPcnt() is False and app.sellUpperPcnt() != None and margin > app.sellUpperPcnt():
@@ -398,10 +383,7 @@ def executeJob(sc, app=PyCryptoBot(), state=AppState(), trading_data=pd.DataFram
                 print(log_text, "\n")
                 logging.warning(log_text)
 
-                # telegram
-                if not app.disableTelegram() and app.isTelegramEnabled():
-                    telegram = app.getChatClient()
-                    telegram.send(app.getMarket() + ' (' + app.printGranularity() + ') ' + log_text)
+                app.notifyTelegram(app.getMarket() + ' (' + app.printGranularity() + ') ' + log_text)
 
             # profit bank when strong reversal detected
             if app.disableProfitbankReversal() is False and margin > 3 and obv_pc < 0 and macdltsignal is True:
@@ -412,10 +394,7 @@ def executeJob(sc, app=PyCryptoBot(), state=AppState(), trading_data=pd.DataFram
                 print(log_text, "\n")
                 logging.warning(log_text)
 
-                # telegram
-                if not app.disableTelegram() and app.isTelegramEnabled():
-                    telegram = app.getChatClient()
-                    telegram.send(app.getMarket() + ' (' + app.printGranularity() + ') ' + log_text)
+                app.notifyTelegram(app.getMarket() + ' (' + app.printGranularity() + ') ' + log_text)
 
             # configuration specifies to not sell at a loss
             if state.action == 'SELL' and not app.allowSellAtLoss() and margin <= 0:
@@ -435,11 +414,8 @@ def executeJob(sc, app=PyCryptoBot(), state=AppState(), trading_data=pd.DataFram
                 print(log_text, "\n")
                 logging.warning(log_text)
 
-                # telegram
-                if not app.disableTelegram() and app.isTelegramEnabled() and not (
-                        not app.allowSellAtLoss() and margin <= 0):
-                    telegram = app.getChatClient()
-                    telegram.send(app.getMarket() + ' (' + app.printGranularity() + ') ' + log_text)
+                if not (not app.allowSellAtLoss() and margin <= 0):
+                    app.notifyTelegram(app.getMarket() + ' (' + app.printGranularity() + ') ' + log_text)
 
         bullbeartext = ''
         if app.disableBullOnly() is True or (df_last['sma50'].values[0] == df_last['sma200'].values[0]):
@@ -502,90 +478,63 @@ def executeJob(sc, app=PyCryptoBot(), state=AppState(), trading_data=pd.DataFram
                 print(log_text, "\n")
                 logging.debug(log_text)
 
-                # telegram
-                if not app.disableTelegram() and app.isTelegramEnabled():
-                    telegram = app.getChatClient()
-                    telegram.send(app.getMarket() + ' (' + app.printGranularity() + ') ' + log_text)
+                app.notifyTelegram(app.getMarket() + ' (' + app.printGranularity() + ') ' + log_text)
 
             if three_black_crows is True:
                 log_text = '* Candlestick Detected: Three Black Crows ("Strong - Reversal - Bearish Pattern - Down")'
                 print(log_text, "\n")
                 logging.debug(log_text)
 
-                # telegram
-                if not app.disableTelegram() and app.isTelegramEnabled():
-                    telegram = app.getChatClient()
-                    telegram.send(app.getMarket() + ' (' + app.printGranularity() + ') ' + log_text)
+                app.notifyTelegram(app.getMarket() + ' (' + app.printGranularity() + ') ' + log_text)
 
             if morning_star is True:
                 log_text = '*** Candlestick Detected: Morning Star ("Strong - Reversal - Bullish Pattern - Up")'
                 print(log_text, "\n")
                 logging.debug(log_text)
 
-                # telegram
-                if not app.disableTelegram() and app.isTelegramEnabled():
-                    telegram = app.getChatClient()
-                    telegram.send(app.getMarket() + ' (' + app.printGranularity() + ') ' + log_text)
+                app.notifyTelegram(app.getMarket() + ' (' + app.printGranularity() + ') ' + log_text)
 
             if evening_star is True:
                 log_text = '*** Candlestick Detected: Evening Star ("Strong - Reversal - Bearish Pattern - Down")'
                 print(log_text, "\n")
                 logging.debug(log_text)
 
-                # telegram
-                if not app.disableTelegram() and app.isTelegramEnabled():
-                    telegram = app.getChatClient()
-                    telegram.send(app.getMarket() + ' (' + app.printGranularity() + ') ' + log_text)
+                app.notifyTelegram(app.getMarket() + ' (' + app.printGranularity() + ') ' + log_text)
 
             if three_line_strike is True:
                 log_text = '** Candlestick Detected: Three Line Strike ("Reliable - Reversal - Bullish Pattern - Up")'
                 print(log_text, "\n")
                 logging.debug(log_text)
 
-                # telegram
-                if not app.disableTelegram() and app.isTelegramEnabled():
-                    telegram = app.getChatClient()
-                    telegram.send(app.getMarket() + ' (' + app.printGranularity() + ') ' + log_text)
+                app.notifyTelegram(app.getMarket() + ' (' + app.printGranularity() + ') ' + log_text)
 
             if abandoned_baby is True:
                 log_text = '** Candlestick Detected: Abandoned Baby ("Reliable - Reversal - Bullish Pattern - Up")'
                 print(log_text, "\n")
                 logging.debug(log_text)
 
-                # telegram
-                if not app.disableTelegram() and app.isTelegramEnabled():
-                    telegram = app.getChatClient()
-                    telegram.send(app.getMarket() + ' (' + app.printGranularity() + ') ' + log_text)
+                app.notifyTelegram(app.getMarket() + ' (' + app.printGranularity() + ') ' + log_text)
 
             if morning_doji_star is True:
                 log_text = '** Candlestick Detected: Morning Doji Star ("Reliable - Reversal - Bullish Pattern - Up")'
                 print(log_text, "\n")
                 logging.debug(log_text)
 
-                # telegram
-                if not app.disableTelegram() and app.isTelegramEnabled():
-                    telegram = app.getChatClient()
-                    telegram.send(app.getMarket() + ' (' + app.printGranularity() + ') ' + log_text)
+                app.notifyTelegram(app.getMarket() + ' (' + app.printGranularity() + ') ' + log_text)
 
             if evening_doji_star is True:
                 log_text = '** Candlestick Detected: Evening Doji Star ("Reliable - Reversal - Bearish Pattern - Down")'
                 print(log_text, "\n")
                 logging.debug(log_text)
 
-                # telegram
-                if not app.disableTelegram() and app.isTelegramEnabled():
-                    telegram = app.getChatClient()
-                    telegram.send(app.getMarket() + ' (' + app.printGranularity() + ') ' + log_text)
+                app.notifyTelegram(app.getMarket() + ' (' + app.printGranularity() + ') ' + log_text)
 
             if two_black_gapping is True:
                 log_text = '*** Candlestick Detected: Two Black Gapping ("Reliable - Reversal - Bearish Pattern - Down")'
                 print(log_text, "\n")
                 logging.debug(log_text)
 
-                # telegram
-                if not app.disableTelegram() and app.isTelegramEnabled():
-                    telegram = app.getChatClient()
-                    telegram.send(app.getMarket() + ' (' + app.printGranularity() + ') ' + log_text)
+                app.notifyTelegram(app.getMarket() + ' (' + app.printGranularity() + ') ' + log_text)
 
             ema_co_prefix = ''
             ema_co_suffix = ''
@@ -768,10 +717,7 @@ def executeJob(sc, app=PyCryptoBot(), state=AppState(), trading_data=pd.DataFram
 
                 # if live
                 if app.isLive():
-                    # telegram
-                    if not app.disableTelegram() and app.isTelegramEnabled():
-                        telegram = app.getChatClient()
-                        telegram.send(app.getMarket() + ' (' + app.printGranularity() + ') BUY at ' + price_text)
+                    app.notifyTelegram(app.getMarket() + ' (' + app.printGranularity() + ') BUY at ' + price_text)
 
                     if not app.isVerbose():
                         logging.info(current_df_index + ' | ' + app.getMarket() + ' | ' + app.printGranularity() +
@@ -852,10 +798,7 @@ def executeJob(sc, app=PyCryptoBot(), state=AppState(), trading_data=pd.DataFram
 
                 # if live
                 if app.isLive():
-                    # telegram
-                    if not app.disableTelegram() and app.isTelegramEnabled():
-                        telegram = app.getChatClient()
-                        telegram.send(app.getMarket() + ' (' + app.printGranularity() + ') SELL at ' +
+                    app.notifyTelegram(app.getMarket() + ' (' + app.printGranularity() + ') SELL at ' +
                                       price_text + ' (margin: ' + margin_text + ', (delta: ' +
                                       str(round(price - state.last_buy_price, precision)) + ')')
 
@@ -1009,28 +952,22 @@ def main():
     try:
         # initialise logging
         logging.basicConfig(
-            filename=app.getLogFile(),
+            # filename=app.getLogFile(),
             format='%(asctime)s - %(levelname)s: %(message)s',
             datefmt='%m/%d/%Y %I:%M:%S %p',
             filemode='a',
             level=logging.DEBUG,
             force=True
         )
-        telegram = None
 
-        if not app.disableTelegram() and app.isTelegramEnabled():
-            telegram = app.getChatClient()
+        message = 'Starting '
+        if app.getExchange() == 'coinbasepro':
+            message += 'Coinbase Pro bot'
+        elif app.getExchange() == 'binance':
+            message += 'Binance bot'
 
-        # telegram
-        if telegram:
-            message = 'Starting '
-            if app.getExchange() == 'coinbasepro':
-                message += 'Coinbase Pro bot'
-            elif app.getExchange() == 'binance':
-                message += 'Binance bot'
-
-            message += ' for ' + app.getMarket() + ' using granularity ' + app.printGranularity()
-            telegram.send(message)
+        message += ' for ' + app.getMarket() + ' using granularity ' + app.printGranularity()
+        app.notifyTelegram(message)
 
         # initialise and start application
         trading_data = app.startApp(account, state.last_action)
@@ -1054,8 +991,7 @@ def main():
                 time.sleep(30)
                 print('Restarting application after exception...')
 
-                if telegram:
-                    telegram.send('Auto restarting bot for ' + app.getMarket() + ' after exception')
+                app.notifyTelegram('Auto restarting bot for ' + app.getMarket() + ' after exception')
 
                 # Cancel the events queue
                 map(s.cancel, s.queue)
@@ -1074,9 +1010,7 @@ def main():
             os._exit(0)
     except(BaseException, Exception) as e:
         # catch all not managed exceptions and send a Telegram message if configured
-        if not app.disableTelegram() and app.isTelegramEnabled():
-            telegram = app.getChatClient()
-            telegram.send('Bot for ' + app.getMarket() + ' got an exception: ' + repr(e))
+        app.notifyTelegram('Bot for ' + app.getMarket() + ' got an exception: ' + repr(e))
 
         print(repr(e))
 


### PR DESCRIPTION
## Description

Instead of the "check is enabled" -> "get client" -> "send message" combo every time code wants to send a message to Telegram, app now offers simple `notifyTelegram()` method:

* with Telegram enabled, it would send the message, as usual.
* with Telegram disabled, it reduces to no-op.

The benefits: separation of concerns, trading code does not care about whether Telegram is enabled or not. Emits notification, leaving the rest to the app. This leads to clearer code with one entry point for all Telegram notifications - should there be a need to modify the notification process, there's just one place to change.

## Type of change

Please make your selection.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This change requires a new dependency
- [x] Code Maintainability / comments
- [x] Code Refactoring / future-proofing

## How Has This Been Tested?

There's no functional change, just refactoring of existing code while preserving its functionality. Tested with my own credentials, feel free to verify on your own.

## Checklist:

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added pytest unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
