### PR TITLE
Fixes formatting of current DF index

### DIFF
--- a/pycryptobot.py
+++ b/pycryptobot.py
@@ -227,6 +227,8 @@ def executeJob(sc, app=PyCryptoBot(), state=AppState(), trading_data=pd.DataFram
     else:
         current_df_index = state.last_df_index
 
+    formatted_current_df_index = f'{current_df_index} 00:00:00' if len(current_df_index) == 10 else current_df_index
+
     if app.getSmartSwitch() == 1 and app.getGranularity() == 3600 and app.is1hEMA1226Bull() is True and app.is6hEMA1226Bull() is True:
         print('*** smart switch from granularity 3600 (1 hour) to 900 (15 min) ***')
 
@@ -579,13 +581,13 @@ def executeJob(sc, app=PyCryptoBot(), state=AppState(), trading_data=pd.DataFram
 
             if not app.isVerbose():
                 if state.last_action != '':
-                    output_text = current_df_index + ' | ' + app.getMarket() + bullbeartext + ' | ' + \
+                    output_text = formatted_current_df_index + ' | ' + app.getMarket() + bullbeartext + ' | ' + \
                                   app.printGranularity() + ' | ' + price_text + ' | ' + ema_co_prefix + \
                                   ema_text + ema_co_suffix + ' | ' + macd_co_prefix + macd_text + macd_co_suffix + \
                                   obv_prefix + obv_text + obv_suffix + state.eri_text + state.action + \
                                   ' | Last Action: ' + state.last_action
                 else:
-                    output_text = current_df_index + ' | ' + app.getMarket() + bullbeartext + ' | ' + \
+                    output_text = formatted_current_df_index + ' | ' + app.getMarket() + bullbeartext + ' | ' + \
                                   app.printGranularity() + ' | ' + price_text + ' | ' + ema_co_prefix + ema_text + \
                                   ema_co_suffix + ' | ' + macd_co_prefix + macd_text + macd_co_suffix + obv_prefix + \
                                   obv_text + obv_suffix + state.eri_text + state.action + ' '
@@ -715,9 +717,9 @@ def executeJob(sc, app=PyCryptoBot(), state=AppState(), trading_data=pd.DataFram
                     app.notifyTelegram(app.getMarket() + ' (' + app.printGranularity() + ') BUY at ' + price_text)
 
                     if not app.isVerbose():
-                        logging.info(current_df_index + ' | ' + app.getMarket() + ' | ' + app.printGranularity() +
+                        logging.info(formatted_current_df_index + ' | ' + app.getMarket() + ' | ' + app.printGranularity() +
                                      ' | ' + price_text + ' | BUY')
-                        print("\n", current_df_index, '|', app.getMarket(), app.printGranularity(), '|', price_text,
+                        print("\n", formatted_current_df_index, '|', app.getMarket(), app.printGranularity(), '|', price_text,
                               '| BUY', "\n")
                     else:
                         print('--------------------------------------------------------------------------------')
@@ -750,9 +752,9 @@ def executeJob(sc, app=PyCryptoBot(), state=AppState(), trading_data=pd.DataFram
                     state.buy_sum = state.buy_sum + state.last_buy_size    
 
                     if not app.isVerbose():
-                        logging.info(current_df_index + ' | ' + app.getMarket() + ' | ' + app.printGranularity() +
+                        logging.info(formatted_current_df_index + ' | ' + app.getMarket() + ' | ' + app.printGranularity() +
                                      ' | ' + price_text + ' | BUY')
-                        print("\n", current_df_index, '|', app.getMarket(), app.printGranularity(), '|', price_text, '| BUY')
+                        print("\n", formatted_current_df_index, '|', app.getMarket(), app.printGranularity(), '|', price_text, '| BUY')
 
                         bands = ta.getFibonacciRetracementLevels(float(price))
                         print(' Fibonacci Retracement Levels:', str(bands))
@@ -796,9 +798,9 @@ def executeJob(sc, app=PyCryptoBot(), state=AppState(), trading_data=pd.DataFram
                                       str(round(price - state.last_buy_price, precision)) + ')')
 
                     if not app.isVerbose():
-                        logging.info(current_df_index + ' | ' + app.getMarket() + ' | ' + app.printGranularity() +
+                        logging.info(formatted_current_df_index + ' | ' + app.getMarket() + ' | ' + app.printGranularity() +
                                      ' | ' + price_text + ' | SELL')
-                        print("\n", current_df_index, '|', app.getMarket(), app.printGranularity(), '|', price_text, '| SELL')
+                        print("\n", formatted_current_df_index, '|', app.getMarket(), app.printGranularity(), '|', price_text, '| SELL')
 
                         bands = ta.getFibonacciRetracementLevels(float(price))
                         print(' Fibonacci Retracement Levels:', str(bands), "\n")
@@ -863,12 +865,13 @@ def executeJob(sc, app=PyCryptoBot(), state=AppState(), trading_data=pd.DataFram
                         else:
                             margin_text = '0%'
 
-                        logging.info(current_df_index + ' | ' + app.getMarket() + ' ' +
+                        logging.info(formatted_current_df_index + ' | ' + app.getMarket() + ' ' +
                                      app.printGranularity() + ' | SELL | ' + str(price) + ' | BUY | ' +
-                                     str(state.last_buy_price) + ' | DIFF | ' + str(profit) + ' | MARGIN NO FEES | ' +
+                                     str(state.last_buy_price) + ' | DIFF | ' + str(price - state.last_buy_price) +
+                                     ' | DIFF | ' + str(profit) + ' | MARGIN NO FEES | ' +
                                      margin_text + ' | MARGIN FEES | ' + str(sell_fee))
-                        print("\n", current_df_index, '|', app.getMarket(), app.printGranularity(), '| SELL |',
-                              str(price), '| BUY |', str(state.last_buy_price), '| DIFF |', str(profit),
+                        print("\n", formatted_current_df_index, '|', app.getMarket(), app.printGranularity(), '| SELL |',
+                              str(price), '| BUY |', str(state.last_buy_price), '| DIFF |', str(price - state.last_buy_price), '| DIFF |', str(profit),
                               '| MARGIN NO FEES |', margin_text, '| MARGIN FEES |', str(round(sell_fee, precision)), "\n")
 
                     else:


### PR DESCRIPTION
## Description

Logging the midnight event is missing the time component, resulting in
malformed "table cell":

```
2021-05-24 23:55:00 | ADAUSDT (BULL) | 5m | Close: 1.55 | ^ EMA12/26: 1.5366 > 1.535 ^ | ^ MACD: 0.0016 > -0.0017 ^ | ^ OBV: 85781895.55 (3.12%) ^ | ERI: sell | WAIT | Last Action: SELL
2021-05-25 | ADAUSDT (BULL) | 5m | Close: 1.5658 | ^ EMA12/26: 1.5411 > 1.5372 ^ | ^ MACD: 0.0038 > -0.0006 ^ | ^ OBV: 91588941.1799 (6.77%) ^ | ERI: buy | WAIT | Last Action: SELL
2021-05-25 00:05:00 | ADAUSDT (BULL) | 5m | Close: 1.5832 | ^ EMA12/26: 1.5476 > 1.5406 ^ | ^ MACD: 0.0069 > 0.0009 ^ | ^ OBV: 98722754.7799 (7.79%) ^ | ERI: buy | WAIT | Last Action: SELL
```

Seems to me it's easier to convert the DF index to its formatted
representation just before printing it.

```
2021-05-24 23:55:00 | ADAUSDT (BULL) | 5m | Close: 1.55 | ^ EMA12/26: 1.5366 > 1.535 ^ | ^ MACD: 0.0016 > -0.0017 ^ | ^ OBV: 85781895.55 (3.12%) ^ | ERI: sell | WAIT | Last Action: SELL
2021-05-25 00:00:00 | ADAUSDT (BULL) | 5m | Close: 1.5658 | ^ EMA12/26: 1.5411 > 1.5372 ^ | ^ MACD: 0.0038 > -0.0006 ^ | ^ OBV: 91588941.1799 (6.77%) ^ | ERI: buy | WAIT | Last Action: SELL
2021-05-25 00:05:00 | ADAUSDT (BULL) | 5m | Close: 1.5832 | ^ EMA12/26: 1.5476 > 1.5406 ^ | ^ MACD: 0.0069 > 0.0009 ^ | ^ OBV: 98722754.7799 (7.79%) ^ | ERI: buy | WAIT | Last Action: SELL
```

~~Fixes # (issue)~~

## Type of change

Please make your selection.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This change requires a new dependency
- [ ] Code Maintainability / comments
- [ ] Code Refactoring / future-proofing

## How Has This Been Tested?

Trivial to test, running simulation before/after the patch.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added pytest unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings