### PR TITLE
Wraps command-line arguments parsing with a function

### DIFF
--- a/models/PyCryptoBot.py
+++ b/models/PyCryptoBot.py
@@ -24,58 +24,60 @@ urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 logging.getLogger("requests").setLevel(logging.WARNING)
 logging.getLogger("urllib3").setLevel(logging.WARNING)
 
-# instantiate the arguments parser
-parser = argparse.ArgumentParser(description='Python Crypto Bot using the Coinbase Pro or Binanace API')
 
-# config builder
-parser.add_argument('--init', action="store_true", help="config.json configuration builder")
+def parse_arguments():
+    # instantiate the arguments parser
+    parser = argparse.ArgumentParser(description='Python Crypto Bot using the Coinbase Pro or Binanace API')
 
-# optional arguments
-parser.add_argument('--exchange', type=str, help="'coinbasepro', 'binance', 'dummy'")
-parser.add_argument('--granularity', type=str,
-                    help="coinbasepro: (60,300,900,3600,21600,86400), binance: (1m,5m,15m,1h,6h,1d)")
-parser.add_argument('--graphs', type=int, help='save graphs=1, do not save graphs=0')
-parser.add_argument('--live', type=int, help='live=1, test=0')
-parser.add_argument('--market', type=str, help='coinbasepro: BTC-GBP, binance: BTCGBP etc.')
-parser.add_argument('--sellatloss', type=int, help='toggle if bot should sell at a loss')
-parser.add_argument('--sellupperpcnt', type=float, help='optionally set sell upper percent limit')
-parser.add_argument('--selllowerpcnt', type=float, help='optionally set sell lower percent limit')
-parser.add_argument('--trailingstoploss',
-                    type=float, help='optionally set a trailing stop percent loss below last buy high')
-parser.add_argument('--sim', type=str, help='simulation modes: fast, fast-sample, slow-sample')
-parser.add_argument('--simstartdate', type=str, help="start date for sample simulation e.g '2021-01-15'")
-parser.add_argument('--smartswitch', type=int, help='optionally smart switch between 1 hour and 15 minute intervals')
-parser.add_argument('--verbose', type=int, help='verbose output=1, minimal output=0')
-parser.add_argument('--config', type=str, help="Use the config file at the given location. e.g 'myconfig.json'")
-parser.add_argument('--logfile', type=str, help="Use the log file at the given location. e.g 'mymarket.log'")
-parser.add_argument('--buypercent', type=int, help="percentage of quote currency to buy")
-parser.add_argument('--sellpercent', type=int, help="percentage of base currency to sell")
-parser.add_argument('--lastaction', type=str, help="optionally set the last action (BUY, SELL)")
-parser.add_argument('--buymaxsize', type=int, help="maximum size on buy")
+    # config builder
+    parser.add_argument('--init', action="store_true", help="config.json configuration builder")
 
-# optional options
-parser.add_argument('--sellatresistance', action="store_true", help="sell at resistance or upper fibonacci band")
-parser.add_argument('--autorestart', action="store_true", help="Auto restart the bot in case of exception")
+    # optional arguments
+    parser.add_argument('--exchange', type=str, help="'coinbasepro', 'binance', 'dummy'")
+    parser.add_argument('--granularity', type=str,
+                        help="coinbasepro: (60,300,900,3600,21600,86400), binance: (1m,5m,15m,1h,6h,1d)")
+    parser.add_argument('--graphs', type=int, help='save graphs=1, do not save graphs=0')
+    parser.add_argument('--live', type=int, help='live=1, test=0')
+    parser.add_argument('--market', type=str, help='coinbasepro: BTC-GBP, binance: BTCGBP etc.')
+    parser.add_argument('--sellatloss', type=int, help='toggle if bot should sell at a loss')
+    parser.add_argument('--sellupperpcnt', type=float, help='optionally set sell upper percent limit')
+    parser.add_argument('--selllowerpcnt', type=float, help='optionally set sell lower percent limit')
+    parser.add_argument('--trailingstoploss',
+                        type=float, help='optionally set a trailing stop percent loss below last buy high')
+    parser.add_argument('--sim', type=str, help='simulation modes: fast, fast-sample, slow-sample')
+    parser.add_argument('--simstartdate', type=str, help="start date for sample simulation e.g '2021-01-15'")
+    parser.add_argument('--smartswitch', type=int, help='optionally smart switch between 1 hour and 15 minute intervals')
+    parser.add_argument('--verbose', type=int, help='verbose output=1, minimal output=0')
+    parser.add_argument('--config', type=str, help="Use the config file at the given location. e.g 'myconfig.json'")
+    parser.add_argument('--logfile', type=str, help="Use the log file at the given location. e.g 'mymarket.log'")
+    parser.add_argument('--buypercent', type=int, help="percentage of quote currency to buy")
+    parser.add_argument('--sellpercent', type=int, help="percentage of base currency to sell")
+    parser.add_argument('--lastaction', type=str, help="optionally set the last action (BUY, SELL)")
+    parser.add_argument('--buymaxsize', type=int, help="maximum size on buy")
 
-# disable defaults
-parser.add_argument('--disablebullonly', action="store_true", help="disable only buying in bull market")
-parser.add_argument('--disablebuynearhigh', action="store_true", help="disable buy within 5 percent of high")
-parser.add_argument('--disablebuymacd', action="store_true", help="disable macd buy signal")
-parser.add_argument('--disablebuyobv', action="store_true", help="disable obv buy signal")
-parser.add_argument('--disablebuyelderray', action="store_true", help="disable elder ray buy signal")
-parser.add_argument(
-    '--disablefailsafefibonaccilow', action="store_true", help="disable failsafe sell on fibonacci lower band")
-parser.add_argument('--disablefailsafelowerpcnt', action="store_true", help="disable failsafe sell on 'selllowerpcnt'")
-parser.add_argument('--disableprofitbankupperpcnt', action="store_true", help="disable profit bank on 'sellupperpcnt'")
-parser.add_argument(
-    '--disableprofitbankreversal', action="store_true", help="disable profit bank on strong candlestick reversal")
-parser.add_argument('--disabletelegram', action="store_true", help="disable telegram messages")
-parser.add_argument('--disablelog', action="store_true", help="disable pycryptobot.log")
-parser.add_argument('--disabletracker', action="store_true", help="disable tracker.csv")
+    # optional options
+    parser.add_argument('--sellatresistance', action="store_true", help="sell at resistance or upper fibonacci band")
+    parser.add_argument('--autorestart', action="store_true", help="Auto restart the bot in case of exception")
 
-# parse arguments
-# args = parser.parse_args()
-args = vars(parser.parse_args())
+    # disable defaults
+    parser.add_argument('--disablebullonly', action="store_true", help="disable only buying in bull market")
+    parser.add_argument('--disablebuynearhigh', action="store_true", help="disable buy within 5 percent of high")
+    parser.add_argument('--disablebuymacd', action="store_true", help="disable macd buy signal")
+    parser.add_argument('--disablebuyobv', action="store_true", help="disable obv buy signal")
+    parser.add_argument('--disablebuyelderray', action="store_true", help="disable elder ray buy signal")
+    parser.add_argument(
+        '--disablefailsafefibonaccilow', action="store_true", help="disable failsafe sell on fibonacci lower band")
+    parser.add_argument('--disablefailsafelowerpcnt', action="store_true", help="disable failsafe sell on 'selllowerpcnt'")
+    parser.add_argument('--disableprofitbankupperpcnt', action="store_true", help="disable profit bank on 'sellupperpcnt'")
+    parser.add_argument(
+        '--disableprofitbankreversal', action="store_true", help="disable profit bank on strong candlestick reversal")
+    parser.add_argument('--disabletelegram', action="store_true", help="disable telegram messages")
+    parser.add_argument('--disablelog', action="store_true", help="disable pycryptobot.log")
+    parser.add_argument('--disabletracker', action="store_true", help="disable tracker.csv")
+
+    # parse arguments
+    # args = parser.parse_args()
+    return vars(parser.parse_args())
 
 
 def to_coinbase_pro_granularity(granularity: int) -> int:
@@ -88,6 +90,8 @@ def to_binance_granularity(granularity: int) -> str:
 
 class PyCryptoBot():
     def __init__(self, exchange='coinbasepro', filename='config.json'):
+        args = parse_arguments()
+
         self.api_key = ''
         self.api_secret = ''
         self.api_passphrase = ''


### PR DESCRIPTION
The arguments are parsed automagically because the parser and the act of
parsing is executed during the import time, when models.PyCryptoBot is
imported. This becomes a problem when attempting imports from tests
running undr pytest: pytest arguments are what parser sees in `sys.argv`,
and it's not possible to *not* parse them which leads to an error,
usually parser reporting "unrecognized arguments".

Therefore wrapping the parser & co. with a function, called when
arguments are needed.

## Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

Please make your selection.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This change requires a new dependency
- [ ] Code Maintainability / comments
- [ ] Code Refactoring / future-proofing

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added pytest unit tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings
