### PR TITLE
[Bug Fix]Allow market pair with 5 characters like ARBNB

### DIFF
--- a/models/TradingAccount.py
+++ b/models/TradingAccount.py
@@ -58,7 +58,7 @@ class TradingAccount():
             if not p.match(market):
                 raise TypeError('Coinbase Pro market is invalid.')
         elif self.app.getExchange() == 'binance':
-            p = re.compile(r"^[A-Z]{6,12}$")
+            p = re.compile(r"^[A-Z]{5,12}$")
             if not p.match(market):
                 raise TypeError('Binance market is invalid.')
 

--- a/models/config/binance_parser.py
+++ b/models/config/binance_parser.py
@@ -6,7 +6,7 @@ from .default_parser import isCurrencyValid, defaultConfigParse, merge_config_an
 def isMarketValid(market) -> bool:
     if market == None:
         return False
-    p = re.compile(r"^[0-9A-Z]{6,12}$")
+    p = re.compile(r"^[0-9A-Z]{5,12}$")
     return p.match(market) is not None
 
 

--- a/models/exchange/binance/api.py
+++ b/models/exchange/binance/api.py
@@ -18,7 +18,7 @@ FREQUENCY_EQUIVALENTS = ["T", "5T", "15T", "H", "6H", "D"]
 DEFAULT_MARKET = "BTCGBP"
 class AuthAPIBase():
     def _isMarketValid(self, market: str) -> bool:
-        p = re.compile(r"^[A-Z0-9]{6,12}$")
+        p = re.compile(r"^[A-Z0-9]{5,12}$")
         if p.match(market):
             return True
         return False


### PR DESCRIPTION
## Description

Some market pairs like `SCBNB, ARBNB` throwing `Binance market is invalid.` errors since `_isMarketvalid()` method returns `False`. So I modified regex to allow market pairs with 5 characters.

## Type of change

Changed the regex string to explicitly allow 5 characters in multiple places.

Please make your selection.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This change requires a new dependency
- [ ] Code Maintainability / comments
- [ ] Code Refactoring / future-proofing

## How Has This Been Tested?

Tested with Binance market pairs with 5 characters and it works flawlessly. 
Some of the other market pairs that can be used for testing.
```
AEBTC
AEETH
AEBNB
SCBTC
SCETH
SCBNB
HCBTC
HCETH
GOBTC
GOBNB
IQBNB
DFETH
OGBTC
OMBTC
EZBTC
EZETH
ARBTC
ARBNB

```

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added pytest unit tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings
