### PR TITLE
Margin hotfix

### DIFF
--- a/pycryptobot.py
+++ b/pycryptobot.py
@@ -327,10 +327,8 @@ def executeJob(sc, app=PyCryptoBot(), state=AppState(), trading_data=pd.DataFram
                 change_pcnt_high = 0
 
             #  buy and sell calculations
-
-            if  state.last_buy_filled == 0:
-                state.last_buy_filled = round(((state.last_buy_size - state.last_buy_fee) / state.last_buy_price), 8)
-                state.last_buy_fee = round(state.last_buy_size * app.getTakerFee(), 8)
+            state.last_buy_fee = round(state.last_buy_size * app.getTakerFee(), 8)
+            state.last_buy_filled = round(((state.last_buy_size - state.last_buy_fee) / state.last_buy_price), 8)
 
             margin, profit, sell_fee = calculate_margin(
                 buy_size=state.last_buy_size,

--- a/tests/unit_tests/test_margin_calculation.py
+++ b/tests/unit_tests/test_margin_calculation.py
@@ -7,9 +7,9 @@ from models.helper.MarginHelper import calculate_margin
 def test_margin_binance():
     # using VET-GBP
     buy_filled= 595.23
-    buy_fee = 0.59523  # round(buy_filled * 0.001, 8)
     buy_price = 0.1249
     buy_size = 74.344227 # round(buy_filled * buy_price, 8)
+    buy_fee = 0.07434423  # round(buy_size * 0.001, 8)
     debug = True
     sell_percent = 100
     sell_price = 0.1335
@@ -34,9 +34,9 @@ def test_margin_binance():
 def test_margin_coinbase_pro():
     # using LINK-GBP
     buy_filled = 8.95
-    buy_fee = 0.04475 # round(buy_filled * 0.005, 8)
     buy_price = 34.50004
     buy_size = 308.775358 # round(buy_filled * buy_price, 8)
+    buy_fee = 1.54387679 # round(buy_size * 0.005, 8)
     debug = True
     sell_percent = 100
     sell_price = 30.66693
@@ -61,9 +61,9 @@ def test_margin_coinbase_pro():
 def test_calculate_negative_margin_on_binance_when_coin_price_over_1():
     # this test using BNB-USDT as market
     buy_filled = 0.067
-    buy_fee = 0.000067 # round(buy_filled * 0.001, 8)
     buy_price = 667.26
     buy_size  = 44.70642 # round(buy_filled * buy_price, 8)
+    buy_fee = 0.04470642 # round(buy_size * 0.001, 8)
     debug = True
     sell_percent = 100
     sell_price = 590.34
@@ -87,9 +87,9 @@ def test_calculate_negative_margin_on_binance_when_coin_price_over_1():
 
 def test_calculate_negative_margin_on_binance_when_coin_price_over_1_2():
     buy_filled = 0.24944
-    buy_fee = 0.00024944 # round(buy_filled * 0.001, 8)
     buy_price = 385.4
     buy_size = 96.134176 # round(buy_filled * buy_price, 8)
+    buy_fee = 0.09613418 # round(buy_size * 0.001, 8)
     debug = False
     sell_percent = 100
     sell_price = 320.95
@@ -114,9 +114,9 @@ def test_calculate_negative_margin_on_binance_when_coin_price_under_1():
     # this test is using CHZ-USDT as market
     
     buy_filled = 177.2
-    buy_fee = 0.1772 # buy_filled(buy_size * 0.001, 8)
     buy_price = 0.4968600000000001
     buy_size = 88.043592 # round(buy_filled * buy_price, 8)
+    buy_fee = 0.1772 # buy_filled(buy_size * 0.001, 8)
     debug = True
     sell_percent = 100
     sell_price = 0.43913 
@@ -128,6 +128,144 @@ def test_calculate_negative_margin_on_binance_when_coin_price_under_1():
     expected_sell_fee = 0.07781384 # round(sell_size * sell_taker_fee, 8)
     expected_profit = -10.30756984 # round(sell_filled - buy_size, 8)
     expected_margin = -11.70734815 # round((expected_profit / buy_size) * 100, 8)
+
+    actual_margin, actual_profit, actual_sell_fee = calculate_margin(buy_size, buy_filled, buy_price, buy_fee,
+                                                                     sell_percent, sell_price, sell_fee, sell_taker_fee,
+                                                                     debug)
+
+    assert round(actual_margin, 8) == round(expected_margin, 8)
+    assert round(actual_profit, 8) == round(expected_profit, 8)
+    assert round(actual_sell_fee, 8) == round(expected_sell_fee, 8)
+
+    
+def test_binance_microtrading_1():
+    # this test is using CHZ-USDT as market
+    
+    buy_filled = 99.9
+    buy_price = 10.0
+    buy_size = 1000 # round(buy_filled * buy_price, 8)
+    buy_fee = 1 # round(buy_size * 0.001, 8)
+    debug = True
+    sell_percent = 100
+    sell_price = 10.0
+    sell_size = 999.0 # round((sell_percent / 100) * (sell_price * buy_filled), 8)
+    sell_taker_fee = 0.001
+    sell_filled = 998.001  # round((sell_size - round(sell_size * sell_taker_fee, 8)), 8)
+    sell_fee = 0.0
+
+    expected_sell_fee = 0.999 # round(sell_size * sell_taker_fee, 8)
+    expected_profit = -1.999 # round(sell_filled - buy_size, 8)
+    expected_margin = -0.1999 # round((expected_profit / buy_size) * 100, 8)
+
+    actual_margin, actual_profit, actual_sell_fee = calculate_margin(buy_size, buy_filled, buy_price, buy_fee,
+                                                                     sell_percent, sell_price, sell_fee, sell_taker_fee,
+                                                                     debug)
+
+    assert round(actual_margin, 8) == round(expected_margin, 8)
+    assert round(actual_profit, 8) == round(expected_profit, 8)
+    assert round(actual_sell_fee, 8) == round(expected_sell_fee, 8)
+
+def test_binance_microtrading_2():
+    # this test is using CHZ-USDT as market
+    
+    buy_filled = 99.9
+    buy_price = 10.0
+    buy_size = 1000 # round(buy_filled * buy_price, 8)
+    buy_fee = 1 # round(buy_size * 0.001, 8)
+    debug = True
+    sell_percent = 100
+    sell_price = 10.0001
+    sell_size = 999.00999 # round((sell_percent / 100) * (sell_price * buy_filled), 8)
+    sell_taker_fee = 0.001
+    sell_filled = 998.01098001  # round((sell_size - round(sell_size * sell_taker_fee, 8)), 8)
+    sell_fee = 0.0
+
+    expected_sell_fee = 0.99900999 # round(sell_size * sell_taker_fee, 8)
+    expected_profit = -1.98901999 # round(sell_filled - buy_size, 8)
+    expected_margin = -0.198902 # round((expected_profit / buy_size) * 100, 8)
+
+    actual_margin, actual_profit, actual_sell_fee = calculate_margin(buy_size, buy_filled, buy_price, buy_fee,
+                                                                     sell_percent, sell_price, sell_fee, sell_taker_fee,
+                                                                     debug)
+
+    assert round(actual_margin, 8) == round(expected_margin, 8)
+    assert round(actual_profit, 8) == round(expected_profit, 8)
+    assert round(actual_sell_fee, 8) == round(expected_sell_fee, 8)
+
+
+def test_binance_microtrading_3():
+    # this test is using CHZ-USDT as market
+    
+    buy_filled = 99.9
+    buy_price = 10.0
+    buy_size = 1000 # round(buy_filled * buy_price, 8)
+    buy_fee = 1 # round(buy_size * 0.001, 8)
+    debug = True
+    sell_percent = 100
+    sell_price = 10.01
+    sell_size = 999.999 # round((sell_percent / 100) * (sell_price * buy_filled), 8)
+    sell_taker_fee = 0.001
+    sell_filled = 998.999001  # round((sell_size - round(sell_size * sell_taker_fee, 8)), 8)
+    sell_fee = 0.0
+
+    expected_sell_fee = 0.999999 # round(sell_size * sell_taker_fee, 8)
+    expected_profit = -1.000999 # round(sell_filled - buy_size, 8)
+    expected_margin = -0.1000999 # round((expected_profit / buy_size) * 100, 8)
+
+    actual_margin, actual_profit, actual_sell_fee = calculate_margin(buy_size, buy_filled, buy_price, buy_fee,
+                                                                     sell_percent, sell_price, sell_fee, sell_taker_fee,
+                                                                     debug)
+
+    assert round(actual_margin, 8) == round(expected_margin, 8)
+    assert round(actual_profit, 8) == round(expected_profit, 8)
+    assert round(actual_sell_fee, 8) == round(expected_sell_fee, 8)
+
+
+def test_binance_microtrading_zero_margin():
+    # this test is using CHZ-USDT as market
+    
+    buy_filled = 99.9
+    buy_price = 10.0
+    buy_size = 1000 # round(buy_filled * buy_price, 8)
+    buy_fee = 1 # round(buy_size * 0.001, 8)
+    debug = True
+    sell_percent = 100
+    sell_price = 10.02003004
+    sell_size = 1001.001001 # round((sell_percent / 100) * (sell_price * buy_filled), 8)
+    sell_taker_fee = 0.001
+    sell_filled = 1000.0  # round((sell_size - round(sell_size * sell_taker_fee, 8)), 8)
+    sell_fee = 0.0
+
+    expected_sell_fee = 1.001001 # round(sell_size * sell_taker_fee, 8)
+    expected_profit = 0.0 # round(sell_filled - buy_size, 8)
+    expected_margin = 0.0 # round((expected_profit / buy_size) * 100, 8)
+
+    actual_margin, actual_profit, actual_sell_fee = calculate_margin(buy_size, buy_filled, buy_price, buy_fee,
+                                                                     sell_percent, sell_price, sell_fee, sell_taker_fee,
+                                                                     debug)
+
+    assert round(actual_margin, 8) == round(expected_margin, 8)
+    assert round(actual_profit, 8) == round(expected_profit, 8)
+    assert round(actual_sell_fee, 8) == round(expected_sell_fee, 8)
+
+def test_binance_microtrading_BNB_max_fee_test():
+    # this test is using CHZ-USDT as market
+    
+    buy_size = 1000 # round(buy_filled * buy_price, 8)
+    buy_fee = 0.75 # round(buy_size * 0.00075, 8)
+    buy_price = 10.0
+    buy_filled = 99.925
+    debug = True
+    sell_percent = 100
+    sell_price = 10.016
+    sell_size = 1000.8488 # round((sell_percent / 100) * (sell_price * buy_filled), 8)
+    sell_taker_fee = 0.00075
+    sell_filled = 1000.0981634  # round((sell_size - round(sell_size * sell_taker_fee, 8)), 8)
+    sell_fee = 0.0
+
+    expected_sell_fee = 0.7506366 # round(sell_size * sell_taker_fee, 8)
+    expected_profit = 0.0981634 # round(sell_filled - buy_size, 8)
+    expected_margin = 0.00981634 # round((expected_profit / buy_size) * 100, 8)
 
     actual_margin, actual_profit, actual_sell_fee = calculate_margin(buy_size, buy_filled, buy_price, buy_fee,
                                                                      sell_percent, sell_price, sell_fee, sell_taker_fee,


### PR DESCRIPTION
## Description
Fixed continuous last_buy_fee and last_buy_filled calculation.

Fixes # (issue)
last_buy_filled was not calculated after first calculation and this was braking the margin calcularion.

## Type of change

Please make your selection.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This change requires a new dependency
- [ ] Code Maintainability / comments
- [] Code Refactoring / future-proofing

## How Has This Been Tested?
Only tested for Binance both live buy and sells.

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added pytest unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
