### PR TITLE
get last buy from exchange and sync with bot for margin calculation

### DIFF
--- a/models/PyCryptoBot.py
+++ b/models/PyCryptoBot.py
@@ -256,7 +256,7 @@ class PyCryptoBot():
     def getVersionFromREADME(self) -> str:
         try:
             count = 0
-            with open('README.md', 'r') as reader:
+            with open('README.md', 'r', encoding='utf8') as reader:
                 line = reader.readline()
                 while count < 5:
                     line = reader.readline()
@@ -546,6 +546,55 @@ class PyCryptoBot():
                 return truncate(val1, precision) + ' = ' + truncate(val2, precision)
             else:
                 return label + ': ' + truncate(val1, precision) + ' = ' + truncate(val2, precision)
+
+    def getLastBuy(self) -> dict:
+        """Retrieves the last exchange buy order and returns a dictionary"""
+
+        try:
+            if self.exchange == 'coinbasepro':
+                api = CBAuthAPI(self.getAPIKey(), self.getAPISecret(), self.getAPIPassphrase(), self.getAPIURL())
+                orders = api.getOrders(self.getMarket(), '', 'done')
+
+                if len(orders) == 0:
+                    return None
+
+                last_order = orders.tail(1)
+                if last_order['action'].values[0] != 'buy':
+                    return None
+
+                return {
+                    'side' : 'buy',
+                    'market' : self.getMarket(),
+                    'size' : float(last_order['size']),
+                    'filled' : float(last_order['filled']),
+                    'price' : float(last_order['price']),
+                    'fee' : float(last_order['fees']),
+                    'date' : str(pd.DatetimeIndex(pd.to_datetime(last_order['created_at']).dt.strftime('%Y-%m-%dT%H:%M:%S.%Z'))[0])
+                }
+            elif self.exchange == 'binance':
+                api = BAuthAPI(self.getAPIKey(), self.getAPISecret(), self.getAPIURL())
+                orders = api.getOrders(self.getMarket())
+
+                if len(orders) == 0:
+                    return None
+
+                last_order = orders.tail(1)
+                if last_order['action'].values[0] != 'buy':
+                    return None
+
+                return {
+                    'side' : 'buy',
+                    'market' : self.getMarket(),
+                    'size' : float(last_order['size']),
+                    'filled' : float(last_order['filled']),
+                    'price' : float(last_order['price']),
+                    'fees' : float(last_order['size'] * 0.001),
+                    'date' : str(pd.DatetimeIndex(pd.to_datetime(last_order['created_at']).dt.strftime('%Y-%m-%dT%H:%M:%S.%Z'))[0])
+                }
+            else:
+                return None
+        except Exception:
+            return None      
 
     def getTakerFee(self):
         if self.exchange == 'coinbasepro':

--- a/pycryptobot.py
+++ b/pycryptobot.py
@@ -327,9 +327,24 @@ def executeJob(sc, app=PyCryptoBot(), state=AppState(), trading_data=pd.DataFram
             else:
                 change_pcnt_high = 0
 
-            #  buy and sell calculations
+            # buy and sell calculations
             state.last_buy_fee = round(state.last_buy_size * app.getTakerFee(), 8)
             state.last_buy_filled = round(((state.last_buy_size - state.last_buy_fee) / state.last_buy_price), 8)
+
+            # if not a simulation, sync with exchange orders
+            if not app.isSimulation():
+                exchange_last_buy = app.getLastBuy()
+                if exchange_last_buy is not None:
+                    if state.last_buy_size != exchange_last_buy['size']:
+                        state.last_buy_size = exchange_last_buy['size']
+                    if state.last_buy_filled != exchange_last_buy['filled']:
+                        state.last_buy_filled = exchange_last_buy['filled']
+                    if state.last_buy_price != exchange_last_buy['price']:
+                        state.last_buy_price = exchange_last_buy['price']
+
+                    if app.getExchange() == 'coinbasepro':
+                        if state.last_buy_fee != exchange_last_buy['fee']:
+                            state.last_buy_fee = exchange_last_buy['fee']
 
             margin, profit, sell_fee = calculate_margin(
                 buy_size=state.last_buy_size,

--- a/script-get_orders.py
+++ b/script-get_orders.py
@@ -16,3 +16,15 @@ account = TradingAccount(app)
 #orders = account.getOrders('DOGEBTC')
 orders = account.getOrders('DOGEBTC', '', 'done')
 print (orders)
+
+# Coinbase Pro last buy
+app = PyCryptoBot(exchange='coinbasepro')
+app.setLive(1)
+result = app.getLastBuy()
+print (result)
+
+# Binance last buy
+app = PyCryptoBot(exchange='binance')
+app.setLive(1)
+result = app.getLastBuy()
+print (result)


### PR DESCRIPTION
## Description

There is a timing issue between the bot storing the last buy details and the order actually being placed. This causes the margin calculation to be out especially if the price is moving quickly. This change retrieves the last buy from the exchange and sync with the bot to give a more accurate profit and margin calculation.

Fixes # https://github.com/whittlem/pycryptobot/issues/230

## Type of change

Please make your selection.

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This change requires a new dependency
- [ ] Code Maintainability / comments
- [ ] Code Refactoring / future-proofing

## How Has This Been Tested?

I've tested this for Coinbase Pro and Binance in live and simulations. I also created a script to manually check the results.

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added pytest unit tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
- [X] I have checked my code and corrected any misspellings
