### PR TITLE
Add BaseException to the restart catch Exception.

### DIFF
--- a/pycryptobot.py
+++ b/pycryptobot.py
@@ -1021,7 +1021,7 @@ def main():
             runApp()
         except KeyboardInterrupt:
             raise
-        except Exception as e:
+        except(BaseException, Exception) as e:
             if app.autoRestart():
                 # Wait 30 second and try to relaunch application
                 time.sleep(30)


### PR DESCRIPTION
## Description

Since Exception is not enough I added BaseException cos some Exception are not inherited from Exception but BaseException and Exception doesn't inherit from BaseException.

Before the PR #276, there was only except statement that was making all type of exception to be catches. Now to catch maximum exceptions, BaseException is also needed.


## Type of change

Please make your selection.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This change requires a new dependency
- [ ] Code Maintainability / comments
- [x] Code Refactoring / future-proofing

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added pytest unit tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
