### PR TITLE
Fix buynearhigh check after a BUY.

### DIFF
--- a/pycryptobot.py
+++ b/pycryptobot.py
@@ -168,7 +168,7 @@ def getAction(now: datetime = datetime.today().strftime('%Y-%m-%d %H:%M:%S'), ap
         action = 'WAIT'
 
     # if disabled, do not buy within 3% of the dataframe close high
-    if app.disableBuyNearHigh() is True and (price > (df['close'].max() * 0.97)):
+    if last_action == 'SELL' and app.disableBuyNearHigh() is True and (price > (df['close'].max() * 0.97)):
         log_text = str(now) + ' | ' + app.getMarket() + ' | ' + \
             app.printGranularity() + ' | Ignoring Buy Signal (price ' + str(price) + ' within 3% of high ' + str(
             df['close'].max()) + ')'


### PR DESCRIPTION
## Description
Prevent false warnings and possible sell error if last_action is 'BUY'

Fixes # (issue)
Check if last_action is SELL to test if buynearhigh is enabled.

## Type of change
-

Please make your selection.

- [ x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This change requires a new dependency
- [ ] Code Maintainability / comments
- [ ] Code Refactoring / future-proofing

## How Has This Been Tested?
Tested with simulator (Binance), running unit tests and live (Binance)

## Checklist:

- [ x ] My code follows the style guidelines of this project
- [ x ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ x ] My changes generate no new warnings
- [ ] I have added pytest unit tests that prove my fix is effective or that my feature works
- [ x ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ x ] I have checked my code and corrected any misspellings
