### PR TITLE
adding last_action polling while bot is running

### DIFF
--- a/models/AppState.py
+++ b/models/AppState.py
@@ -100,15 +100,9 @@ class AppState():
                 sys.tracebacklimit = 0
                 raise Exception(f'Insufficient Quote Funds! (Actual: {"{:.8f}".format((quote / price))}, Minimum: {base_min})')
 
-    def initLastAction(self):
-        # ignore if manually set
-        if self.app.getLastAction() is not None:
-            self.last_action = self.app.getLastAction()
-            return
-
+    def getLastOrder(self):
         # if not live
         if not self.app.isLive():
-            self.last_action = 'SELL'
             return
 
         orders = self.account.getOrders(self.app.getMarket(), '', 'done')
@@ -156,3 +150,14 @@ class AppState():
                 self.last_action = 'WAIT'
 
             return
+
+    def initLastAction(self):
+        # ignore if manually set
+        if self.app.getLastAction() is not None:
+            self.last_action = self.app.getLastAction()
+            return
+
+        self.getLastOrder()
+
+    def pollLastAction(self):
+        self.getLastOrder()

--- a/pycryptobot.py
+++ b/pycryptobot.py
@@ -107,6 +107,14 @@ def executeJob(sc=None, app: PyCryptoBot=None, state: AppState=None, trading_dat
     if len(df_last) > 0:
         now = datetime.today().strftime('%Y-%m-%d %H:%M:%S')
 
+        # last_action polling if live
+        if app.isLive(): 
+            last_action_current = state.last_action
+            state.pollLastAction()
+            if last_action_current != state.last_action:
+                Logger.info(f'last_action change detected from {last_action_current} to {state.last_action}')
+                app.notifyTelegram(f"{app.getMarket} last_action change detected from {last_action_current} to {state.last_action}")
+
         if not app.isSimulation():
             ticker = app.getTicker(app.getMarket())
             now = ticker[0]


### PR DESCRIPTION
## Description

Adding polling of last_action while bot is running to pick up manual orders without having to restart.

Fixes # https://github.com/whittlem/pycryptobot/issues/328

## Type of change

Please make your selection.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This change requires a new dependency
- [ ] Code Maintainability / comments
- [ ] Code Refactoring / future-proofing

## How Has This Been Tested?

Manual and unit testing

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added pytest unit tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
- [X] I have checked my code and corrected any misspellings
