### PR TITLE
Fix Float division by zero due to missing last action in simulation

### DIFF
--- a/models/AppState.py
+++ b/models/AppState.py
@@ -103,6 +103,7 @@ class AppState():
     def getLastOrder(self):
         # if not live
         if not self.app.isLive():
+            self.last_action = 'SELL'
             return
 
         orders = self.account.getOrders(self.app.getMarket(), '', 'done')


### PR DESCRIPTION
## Description
last_action was missing in simulations, causing a Float division by zero error 

Fixes #340 

## Type of change

Please make your selection.

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
Ran a KAVAUSDT simulation twice, once without and once with the line placed back in. Fixed the issue