### PR TITLE
Fix missings stats default causing bot to crash without --stats

### DIFF
--- a/models/PyCryptoBot.py
+++ b/models/PyCryptoBot.py
@@ -150,6 +150,7 @@ class PyCryptoBot():
 
         self.sellatresistance = False
         self.autorestart = False
+        self.stats = False
 
         self.disablebullonly = False
         self.disablebuynearhigh = False


### PR DESCRIPTION
## Description
The newly release v2.35.0 added the stats parameter, but the stats parameter was omitted from the constructor. So now it fails startup when it's not set.

Was introduced with #344.

## Type of change

Please make your selection.
- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
Bot wouldn't start without --stats, will start without it now.