### PR TITLE
Add "api_key_file" to the config to (eventually) replace "api_key / config"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ Upgrade version:
 Upgrade library dependancies (if required):
 - python3 -m pip install -r requirements.txt -U
 
-## [2.38.1] - 2021-06-27
+## [2.39.0] - 2021-06-27
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ Upgrade version:
 Upgrade library dependancies (if required):
 - python3 -m pip install -r requirements.txt -U
 
+## [2.38.1] - 2021-06-27
+
+### Changed
+
+-- Added "api_key_file" to config to keep credentials out of config files for safety
+
 ## [2.38.0] - 2021-06-23
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -275,6 +275,25 @@ In order to trade live you need to authenticate with the Coinbase Pro or Binance
 
 `simstartdate` takes priority over `simenddate` if both are given
 
+## API key / secret / password storage
+
+From now on it's recommended NOT to store the credentials in the config file because people share configs and may inadvertently share their API keys within.
+
+Instead, please, create `binance.key` or `coinbase.key` (or use your own names for the files) and refer to these files in the config as:
+
+    "api_key_file" : "binance.key"
+
+Once you have done that, "api_key" and "api_secret" can be safely removed from your config file and you're free to share your configs without worrying of leaked credentials.
+
+### binance.key / conbase.key examples
+
+Actually it's pretty simple, these files are supposed to be a simple text files with the API key on the first line, API secret on the second line and in case of coinbase, probably the API password on the third. No comments or anything else is allowed, just the long string of numbers:
+
+    0234238792873423...82736827638472
+    68473847745876abscd9872...8237642
+
+(dots are used to indicate places where the strings were shortened)
+
 ## config.json examples
 
 Coinbase Pro basic (using smart switching)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![Docker](https://github.com/whittlem/pycryptobot/actions/workflows/container.yml/badge.svg)](https://github.com/whittlem/pycryptobot/actions/workflows/container.yml/badge.svg) [![Tests](https://github.com/whittlem/pycryptobot/actions/workflows/unit-tests.yml/badge.svg)](https://github.com/whittlem/pycryptobot/actions/workflows/unit-tests.yml/badge.svg)
 
-# Python Crypto Bot v2.38.0 (pycryptobot)
+# Python Crypto Bot v2.38.1 (pycryptobot)
 
 ## Join our chat on Telegram
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![Docker](https://github.com/whittlem/pycryptobot/actions/workflows/container.yml/badge.svg)](https://github.com/whittlem/pycryptobot/actions/workflows/container.yml/badge.svg) [![Tests](https://github.com/whittlem/pycryptobot/actions/workflows/unit-tests.yml/badge.svg)](https://github.com/whittlem/pycryptobot/actions/workflows/unit-tests.yml/badge.svg)
 
-# Python Crypto Bot v2.38.1 (pycryptobot)
+# Python Crypto Bot v2.39.0 (pycryptobot)
 
 ## Join our chat on Telegram
 

--- a/models/config/binance_parser.py
+++ b/models/config/binance_parser.py
@@ -46,6 +46,20 @@ def parser(app, binance_config, args={}):
     if not app:
         raise Exception('No app is passed')
 
+    if 'api_key' in binance_config or 'api_secret' in binance_config:
+        print('* "api_key / secret" should be saved in a separate file referred as "api_key_file"')
+        print('* the file should be a simple text file with key / secret on separate lines\n')
+
+    if 'api_key_file' in binance_config:
+        try :
+            with open( binance_config['api_key_file'], 'r') as f :
+                key = f.readline().strip()
+                secret = f.readline().strip()
+            binance_config['api_key'] = key
+            binance_config['api_secret'] = secret
+        except :
+            raise RuntimeError('Unable to read ' + binance_config['api_key_file'])
+
     if 'api_key' in binance_config and 'api_secret' in binance_config and 'api_url' in binance_config:
         # validates the api key is syntactically correct
         p = re.compile(r"^[A-z0-9]{64,64}$")

--- a/models/config/binance_parser.py
+++ b/models/config/binance_parser.py
@@ -41,7 +41,7 @@ def parser(app, binance_config, args={}):
     #print('Binance Configuration parse')
 
     if not binance_config:
-        raise Exception('There is an error in your config dictionnary')
+        raise Exception('There is an error in your config dictionary')
 
     if not app:
         raise Exception('No app is passed')

--- a/models/config/coinbase_pro_parser.py
+++ b/models/config/coinbase_pro_parser.py
@@ -24,6 +24,22 @@ def parser(app, coinbase_config, args={}):
     if not app:
         raise Exception('No app is passed')
 
+    if 'api_key' in coinbase_config or 'api_secret' in coinbase_config:
+        print('* "api_key / secret" should be saved in a separate file referred as "api_key_file"')
+        print('* the file should be a simple text file with key/secret/passwd on separate lines\n')
+
+    if 'api_key_file' in coinbase_config:
+        try :
+            with open( coinbase_config['api_key_file'], 'r') as f :
+                key = f.readline().strip()
+                secret = f.readline().strip()
+                password = f.readline().strip()
+            coinbase_config['api_key'] = key
+            coinbase_config['api_secret'] = secret
+            coinbase_config['api_passphrase'] = password
+        except :
+            raise RuntimeError('Unable to read ' + coinbase_config['api_key_file'])
+
     if 'api_key' in coinbase_config and 'api_secret' in coinbase_config and \
             'api_passphrase' in coinbase_config and 'api_url' in coinbase_config:
 


### PR DESCRIPTION
## Description

New keyword introduced to the config file that allows to store credentials for the exchange as a separate file.
This should help to keep the credentials safe and avoid posting them in public forums when exchanging configs.

## Type of change

Please make your selection.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update
- [ ] This change requires a new dependency
- [ ] Code Maintainability / comments
- [x] Code Refactoring / future-proofing

## How Has This Been Tested?

Runs well on my PC

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added pytest unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
