### PR TITLE
Accommodate for bigger ID in telegram.py, fix re.match bug with leading sign(s)

### DIFF
--- a/models/chat/telegram.py
+++ b/models/chat/telegram.py
@@ -13,7 +13,7 @@ class Telegram():
         if not p.match(token):
             raise Exception('Telegram token is invalid')
 
-        p = re_compile(r"^-*\d{7,10}$")
+        p = re_compile(r"^-?\d{7,13}$")
         if not p.match(client_id):
             raise Exception('Telegram client_id is invalid')
 


### PR DESCRIPTION
## Description

`r"^-*\d{7,10}$"` allowed several minus signs before the number, which seems to be incorrect, besides, newly generated Telegram IDs are getting bigger, changed the possible length up a few digits, resulting in `r"^-?\d{7,13}$"`

## Type of change

Please make your selection.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This change requires a new dependency
- [x] Code Maintainability / comments
- [x] Code Refactoring / future-proofing

## How Has This Been Tested?

Works well on my PC

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added pytest unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
