### PR TITLE
fix(getOrders): Retrieve only filled orders

### DIFF
--- a/models/exchange/binance/api.py
+++ b/models/exchange/binance/api.py
@@ -201,6 +201,10 @@ class AuthAPI(AuthAPIBase):
         if len(df) == 0:
             return pd.DataFrame()
 
+        # fix: float division by zero
+        # remove pending orders with status new (i.e. order made by user at limit)
+        df = df[df['status'] == "FILLED"]
+
         # replace null NaN values with 0
         df.fillna(0, inplace=True)
 


### PR DESCRIPTION
## Description

The retrieved orders (from `getOrders`) contain orders with status `filled` and `new`.
The `new` orders do not contain any `buy_size` correct value. So it is converted as a `0` (zero) and the calling method raise this error.
This fix solve the "float division by zero" error message when running the bot in parallele of trading on limits.

## Type of change

Please make your selection.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This change requires a new dependency
- [ ] Code Maintainability / comments
- [ ] Code Refactoring / future-proofing

## How Has This Been Tested?

Actions step-by-step:
* Run the bot on a currency on live (real money). The other config params does not matter.
* Make a manuel buy order from the app at limit (much) lower than the current price (so not yet reached and give you time to see the bug coming)
* See the unstoppable errors appearing on your telegram chat (roughly 1 message per second)

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added pytest unit tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [X] I have checked my code and corrected any misspellings
