### PR TITLE
Fix to ARIMA model bug in coinbase pro

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Upgrade version:
 Upgrade library dependancies (if required):
 - python3 -m pip install -r requirements.txt -U
 
+## [2.44.2] - 2021-07-05
+
+-- Fixed ARIMA bug in coinbase pro when frequency not set in dataframe
+
 ## [2.44.1] - 2021-07-05
 
 ### Changed

--- a/models/Trading.py
+++ b/models/Trading.py
@@ -543,8 +543,11 @@ class TechnicalAnalysis():
         """Returns the Seasonal ARIMA Model for price predictions"""
 
         # hyperparameters for SARIMAX
+        print(self.df.index)
         if not self.df.index.freq:
-            self.df.index = self.df.index.to_period(str(self.df['granularity'].iloc[-1]) + 'S')
+            freq = str(self.df['granularity'].iloc[-1]).replace("m","T").replace("h","H").replace("d","D")
+            if freq.isdigit(): freq += 'S'
+            self.df.index = self.df.index.to_period(freq)
         model = SARIMAX(self.df['close'], trend='n', order=(0,1,0), seasonal_order=(1,1,1,12))
         return model.fit(disp=-1)
 

--- a/models/Trading.py
+++ b/models/Trading.py
@@ -543,6 +543,8 @@ class TechnicalAnalysis():
         """Returns the Seasonal ARIMA Model for price predictions"""
 
         # hyperparameters for SARIMAX
+        if not self.df.index.freq:
+            self.df.index = self.df.index.to_period(str(self.df['granularity'].iloc[-1]) + 'S')
         model = SARIMAX(self.df['close'], trend='n', order=(0,1,0), seasonal_order=(1,1,1,12))
         return model.fit(disp=-1)
 

--- a/models/Trading.py
+++ b/models/Trading.py
@@ -543,7 +543,6 @@ class TechnicalAnalysis():
         """Returns the Seasonal ARIMA Model for price predictions"""
 
         # hyperparameters for SARIMAX
-        print(self.df.index)
         if not self.df.index.freq:
             freq = str(self.df['granularity'].iloc[-1]).replace("m","T").replace("h","H").replace("d","D")
             if freq.isdigit(): freq += 'S'


### PR DESCRIPTION
## Description
Bug in the ARIMA model in coinbase pro when using a small granularity. Get the following warning (and no ARIMA prediction).

/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages/statsmodels/tsa/base/tsa_model.py:581: ValueWarning: A date index has been provided, but it has no associated frequency information and so will be ignored when e.g. forecasting.
  warnings.warn('A date index has been provided, but it has no'

This is reproducible by using MATIC-GBP on coinbase pro with granularity of 5m. 
In this case I noticed that the datetime index of the dataframe had a frequency of None - which is usually inferred.

Fixes # (issue)
#329
#334

## Type of change

Please make your selection.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This change requires a new dependency
- [ ] Code Maintainability / comments
- [ ] Code Refactoring / future-proofing

## How Has This Been Tested?

I've checked this with several pairs on coinbase pro and on binance.
I don't think that this happens on binance (or I didn't come across it when testing)

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added pytest unit tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings
