### PR TITLE
Fix granularity problem in getHistoricalDateRange()

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![Docker](https://github.com/whittlem/pycryptobot/actions/workflows/container.yml/badge.svg)](https://github.com/whittlem/pycryptobot/actions/workflows/container.yml/badge.svg) [![Tests](https://github.com/whittlem/pycryptobot/actions/workflows/unit-tests.yml/badge.svg)](https://github.com/whittlem/pycryptobot/actions/workflows/unit-tests.yml/badge.svg)
 
-# Python Crypto Bot v2.46.0 (pycryptobot)
+# Python Crypto Bot v2.46.1 (pycryptobot)
 
 ## Join our chat on Telegram
 

--- a/models/PyCryptoBot.py
+++ b/models/PyCryptoBot.py
@@ -375,7 +375,7 @@ class PyCryptoBot():
             return pd.DataFrame()
 
     def getHistoricalDataChained(self, market, granularity: int, max_interations: int=1) -> pd.DataFrame:
-        df1 = self.getHistoricalData(market, self.getGranularity())
+        df1 = self.getHistoricalData(market, granularity)
 
         if max_interations == 1:
             return df1


### PR DESCRIPTION
## Fix granularity problem in getHistoricalDateRange()

Use `granularity` instead of `self.getGranularity()`  in `getHistoricalDateRange()` call

Fixes # (issue)

## Type of change

Please make your selection.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This change requires a new dependency
- [ ] Code Maintainability / comments
- [ ] Code Refactoring / future-proofing

## How Has This Been Tested?

Works well on my PC

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added pytest unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings
