### PR TITLE
Return local time if binance server time is not available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ Upgrade version:
 Upgrade library dependancies (if required):
 - python3 -m pip install -r requirements.txt -U
 
+## [2.47.2] - 2021-07-14
+
+### Changed
+
+-- Fixed missing server time (binance) issue
+
 ## [2.47.1] - 2021-07-13
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![Docker](https://github.com/whittlem/pycryptobot/actions/workflows/container.yml/badge.svg)](https://github.com/whittlem/pycryptobot/actions/workflows/container.yml/badge.svg) [![Tests](https://github.com/whittlem/pycryptobot/actions/workflows/unit-tests.yml/badge.svg)](https://github.com/whittlem/pycryptobot/actions/workflows/unit-tests.yml/badge.svg)
 
-# Python Crypto Bot v2.47.1 (pycryptobot)
+# Python Crypto Bot v2.47.2 (pycryptobot)
 
 ## Join our chat on Telegram
 

--- a/models/exchange/binance/api.py
+++ b/models/exchange/binance/api.py
@@ -365,7 +365,7 @@ class AuthAPI(AuthAPIBase):
             epoch = int(str(resp['serverTime'])[0:10])
             return datetime.fromtimestamp(epoch)
         except:
-            return None
+            return datetime.now()
 
 
 class PublicAPI(AuthAPIBase):

--- a/models/exchange/binance/api.py
+++ b/models/exchange/binance/api.py
@@ -515,5 +515,5 @@ class PublicAPI(AuthAPIBase):
             epoch = int(str(resp['serverTime'])[0:10])
             return datetime.fromtimestamp(epoch)
         except:
-            return None
+            return datetime.now()
 


### PR DESCRIPTION
## Return valid `datetime` object instead of `None` if binance failed to provide the server time

When the bot reads the time from the binance server and fails, it returns `None`, which breaks the downstream logic with time processing (because `None` is not `datetime`). Returning local time in case when the server time is not available should fix the problem.

Fixes #333 

## Type of change

Please make your selection.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This change requires a new dependency
- [x] Code Maintainability / comments
- [ ] Code Refactoring / future-proofing

## How Has This Been Tested?

Works well on my PC.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added pytest unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings
