### PR TITLE
fix gitignore to include configmap.yaml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -151,4 +151,4 @@ pycryptobot.log.*
 tests/unit_tests/data/*.json
 
 *.key
-config*.yaml
+config-*.yaml

--- a/chart/templates/configmap.yaml
+++ b/chart/templates/configmap.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "pycryptobot.fullname" . }}
+  labels:
+    {{- include "pycryptobot.labels" . | nindent 4 }}
+data:
+  config.json: |-
+{{ .Values.config | indent 4 }}


### PR DESCRIPTION
## Description

@whittlem Sorry, just noticed this:

The gitignore pattern excluded the configmap.yaml for the helm chart.

## Type of change

Please make your selection.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This change requires a new dependency
- [ ] Code Maintainability / comments
- [ ] Code Refactoring / future-proofing


