### PR TITLE
add section about code style to contributing.md

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -47,12 +47,16 @@ In general, we follow the ["fork-and-pull" Git workflow](https://github.com/susa
 1. Fork the repository to your own Github account
 2. Clone the project to your machine
 3. Create a branch locally with a succinct but descriptive name
- * feature_<name> for feature branches
- * hotfix_<name> for hotfix branches
+     * feature_<name> for feature branches
+     * hotfix_<name> for hotfix branches
 4. Commit changes to the branch
-5. Following any formatting and testing guidelines specific to this repo
+5. Following any [formatting](#code-style-conventions) and testing guidelines specific to this repo
 6. Push changes to your fork
 7. Open a PR in this repository and follow the PR template so that we can efficiently review the changes.
+
+### Code Style Conventions
+
+Please use [black](https://github.com/psf/black) to format your code before opening a pull request.
 
 ## Getting Help
 

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -47,12 +47,13 @@ In general, we follow the ["fork-and-pull" Git workflow](https://github.com/susa
 1. Fork the repository to your own Github account
 2. Clone the project to your machine
 3. Create a branch locally with a succinct but descriptive name
-     * feature_<name> for feature branches
-     * hotfix_<name> for hotfix branches
+     * `feature_name` or `feature/name` for feature branches
+     * `hotfix_name` or `hotfix/name` for hotfix branches
 4. Commit changes to the branch
 5. Following any [formatting](#code-style-conventions) and testing guidelines specific to this repo
-6. Push changes to your fork
-7. Open a PR in this repository and follow the PR template so that we can efficiently review the changes.
+6. Increment the version number in the [README](../README.md). Try and follow [SemVer](https://semver.org/). If you're unsure, reach out to the contributors.
+7. Push changes to your fork
+8. Open a PR in this repository and follow the PR template so that we can efficiently review the changes.
 
 ### Code Style Conventions
 


### PR DESCRIPTION
Signed-off-by: Norbert Varzariu <loomsen@gmail.com>

## Description

This PR adds a "code style conventions" section to the contribution document, pointing out that `black` should be used as the default code formatter.

## Type of change

Please make your selection.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update
- [ ] This change requires a new dependency
- [ ] Code Maintainability / comments
- [ ] Code Refactoring / future-proofing

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

## Checklist:

- [x] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added pytest unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
