### PR TITLE
Fixes - recv_window and replace tabs in configs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ Upgrade version:
 Upgrade library dependancies (if required):
 - python3 -m pip install -r requirements.txt -U
 
+## [3.0.1] - 2021-08-07
+
+### Changed
+
+-- Fix recvWindow for binance
+
 ## [3.0.0] - 2021-08-03
 
 ### Changed
@@ -73,7 +79,7 @@ Upgrade library dependancies (if required):
 ### Changed
 
 -- Fixed smartwitch for coinbase historic data limit
--- Fixed smartswitching date sync 
+-- Fixed smartswitching date sync
 
 ## [2.46.2] - 2021-07-13
 
@@ -206,52 +212,52 @@ Upgrade library dependancies (if required):
 -- Updated unit tests
 
 ## [2.31.1] - 2021-06-13
-  
+
 ### Changed
 
 -- Create default config if missing, avoid creating empty config
 
 ## [2.31.0] - 2021-06-13
-  
+
 ### Changed
 
 -- Separated strategy into Strategy model for custom strategies
 
 ## [2.30.2] - 2021-06-12
-  
+
 ### Changed
 
 -- Minor changes in quote currency extraction (binance.py)
 
 ## [2.30.1] - 2021-06-12
-  
+
 ### Changed
 
 -- Suppressed ARIMA model warning
 
 ## [2.30.0] - 2021-06-12
-  
+
 ### Changed
 
 -- Improved ARIMA model output to console
 -- Reduced polling from 2 minutes to 1 minute
 
 ## [2.29.0] - 2021-06-11
-  
+
 ### Added
 
 -- Added the Seasonal ARIMA machine learning model for price predictions
 
 ## [2.28.0] - 2021-06-11
-  
+
 ### Added
 
 -- Added Stochastic RSI and Williams %R technical indicators
 
 ## [2.27.0] - 2021-06-08
-  
+
 ### Changed
-  
+
 - Optimised simulations, they run a lot faster now
 
 ### Added
@@ -259,21 +265,21 @@ Upgrade library dependancies (if required):
 -- Added app.getHistoricalDataChained
 
 ## [2.26.0] - 2021-06-07
-  
+
 ### Changed
-  
+
 - Updated validation to allow for custom Coinbase Pro passphrases
- 
+
 ## [2.25.0] - 2021-06-06
-  
+
 ### Added
 
 - Added CHANGELOG.md
- 
+
 ### Changed
-  
+
 - Removed check for 'fees' on Binance orders which doesn't exist
- 
+
 ### Fixed
- 
+
 - Pandas 'SettingWithCopyWarning' in models/exchange/coinbase_pro/api.py

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![Docker](https://github.com/whittlem/pycryptobot/actions/workflows/container.yml/badge.svg)](https://github.com/whittlem/pycryptobot/actions/workflows/container.yml/badge.svg) [![Tests](https://github.com/whittlem/pycryptobot/actions/workflows/unit-tests.yml/badge.svg)](https://github.com/whittlem/pycryptobot/actions/workflows/unit-tests.yml/badge.svg)
 
-# Python Crypto Bot v3.0.0 (pycryptobot)
+# Python Crypto Bot v3.0.1 (pycryptobot)
 
 ## Join our chat on Telegram
 

--- a/models/Config.py
+++ b/models/Config.py
@@ -1,4 +1,5 @@
 import argparse
+import fileinput
 import os
 import re
 import sys
@@ -111,6 +112,11 @@ class Config:
         if os.path.isfile(self.config_file):
             self.config_provided = True
             try:
+                # replace tabs in config files, yaml doesn't support tabs and wants spaces
+                with fileinput.FileInput(self.config_file, inplace=True) as stream:
+                    for line in stream:
+                        print(line.replace("\t", "  "), end="")
+
                 with open(self.config_file, "r") as stream:
                     self.config = yaml.safe_load(stream)
 
@@ -234,7 +240,7 @@ class Config:
 
     def getVersionFromREADME(self) -> str:
         regex = r"^# Python Crypto Bot (v(?:\d+.){2}\d(?:-[\w\d]+)?).*"
-        version = 'v0.0.0'
+        version = "v0.0.0"
         try:
             with open("README.md", "r", encoding="utf8") as stream:
                 for line in stream:
@@ -254,7 +260,9 @@ class Config:
             if 5000 <= int(self.cli_args["recvWindow"]) <= 60000:
                 recv_window = int(self.cli_args["recvWindow"])
             else:
-                raise ValueError("recvWindow out of bounds! Should be between 5000 and 60000.")
+                raise ValueError(
+                    "recvWindow out of bounds! Should be between 5000 and 60000."
+                )
         return recv_window
 
     def _parse_arguments(self):

--- a/models/Config.py
+++ b/models/Config.py
@@ -251,13 +251,10 @@ class Config:
     def _set_recv_window(self):
         recv_window = 5000
         if self.cli_args["recvWindow"] and isinstance(self.cli_args["recvWindow"], int):
-            if (
-                int(self.cli_args["recvWindow"]) >= 5000
-                and int(self.cli_args["recvWindow"]) <= 60000
-            ):
-                recv_window = 5000
+            if 5000 <= int(self.cli_args["recvWindow"]) <= 60000:
+                recv_window = int(self.cli_args["recvWindow"])
             else:
-                raise ValueError("recvWindow out of bounds!")
+                raise ValueError("recvWindow out of bounds! Should be between 5000 and 60000.")
         return recv_window
 
     def _parse_arguments(self):


### PR DESCRIPTION
- receive_window was always set to 5000. If the user supplies a valid value between 5000 and 60000, it will now be used.
- came up yesterday in the evening: some users had literal tabs in their config.json, this is not supported by the yaml parser. tabs will be replaces with spaces now to address this

## Type of change

Please make your selection.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This change requires a new dependency
- [ ] Code Maintainability / comments
- [ ] Code Refactoring / future-proofing

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added pytest unit tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings
