### PR TITLE
fix initial config generator and set default market

### DIFF
--- a/models/Config.py
+++ b/models/Config.py
@@ -1,5 +1,6 @@
 import argparse
 import fileinput
+import json
 import os
 import re
 import sys
@@ -22,10 +23,6 @@ from models.helper.LogHelper import Logger
 class Config:
     def __init__(self, *args, **kwargs):
         self.cli_args = self._parse_arguments()
-
-        if self.cli_args["init"]:
-            ConfigBuilder().init()
-            sys.exit()
 
         self.configbuilder = False
 
@@ -98,6 +95,11 @@ class Config:
         )
 
         self.config_file = kwargs.get("config_file", "config.json")
+
+        if self.cli_args["init"] or (self.config_file == 'config.json' and not os.path.isfile(self.config_file)):
+            ConfigBuilder().init()
+            sys.exit()
+
         self.config_provided = False
         self.config = {}
 
@@ -105,20 +107,15 @@ class Config:
             self.config_file = self.cli_args["config"]
             self.config_provided = True
 
-        if self.config_file == "config.json" and not os.path.isfile(self.config_file):
-            self.is_live = 0  # no config will prevent live mode
-
         # read and set config from file
         if os.path.isfile(self.config_file):
             self.config_provided = True
             try:
-                # replace tabs in config files, yaml doesn't support tabs and wants spaces
-                with fileinput.FileInput(self.config_file, inplace=True) as stream:
-                    for line in stream:
-                        print(line.replace("\t", "  "), end="")
-
                 with open(self.config_file, "r") as stream:
-                    self.config = yaml.safe_load(stream)
+                    try:
+                        self.config = yaml.safe_load(stream)
+                    except ScannerError:
+                        self.config = json.load(stream)
 
             except (ScannerError, ConstructorError) as err:
                 sys.tracebacklimit = 0
@@ -146,8 +143,8 @@ class Config:
             self.api_key,
             self.api_secret,
             self.api_passphrase,
+            self.market
         ) = self._set_default_api_info(self.exchange)
-        self.market = "BTCGBP"
 
         if self.config_provided:
             if self.exchange == "coinbasepro" and "coinbasepro" in self.config:
@@ -217,18 +214,21 @@ class Config:
                 "api_key": "0000000000000000000000000000000000000000000000000000000000000000",
                 "api_secret": "0000000000000000000000000000000000000000000000000000000000000000",
                 "api_passphrase": "",
+                "market": "BTCGBP"
             },
             "coinbasepro": {
                 "api_url": "https://api.pro.coinbase.com",
                 "api_key": "00000000000000000000000000000000",
                 "api_secret": "0000/0000000000/0000000000000000000000000000000000000000000000000000000000/00000000000==",
                 "api_passphrase": "00000000000",
+                "market": "BTC-GBP"
             },
             "dummy": {
                 "api_url": "https://api.pro.coinbase.com",
                 "api_key": "00000000000000000000000000000000",
                 "api_secret": "0000/0000000000/0000000000000000000000000000000000000000000000000000000000/00000000000==",
                 "api_passphrase": "00000000000",
+                "market": "BTC-GBP"
             },
         }
         return (
@@ -236,6 +236,7 @@ class Config:
             conf[exchange]["api_key"],
             conf[exchange]["api_secret"],
             conf[exchange]["api_passphrase"],
+            conf[exchange]["market"]
         )
 
     def getVersionFromREADME(self) -> str:

--- a/models/Config.py
+++ b/models/Config.py
@@ -114,8 +114,12 @@ class Config:
                 with open(self.config_file, "r") as stream:
                     try:
                         self.config = yaml.safe_load(stream)
-                    except ScannerError:
-                        self.config = json.load(stream)
+                    except:
+                        try:
+                            self.config = json.load(stream)
+                        except json.decoder.JSONDecodeError as err:
+                            sys.tracebacklimit = 0
+                            raise ValueError('Invalid config.json: ' + str(err))
 
             except (ScannerError, ConstructorError) as err:
                 sys.tracebacklimit = 0


### PR DESCRIPTION
Signed-off-by: Norbert Varzariu <loomsen@gmail.com>

## Description

ConfigBuilder was broken if someone downloaded the project and started it for the first time. Also the wrong default market was set.

Fixes #416 

Further I'm now also trying to parse the provided config with the same mechanism that was used before, if yaml fails. Some users complained about errors when they had literal tab characters in their json files. For my tests, the `json.load` also fails when I have a tab in my config.json. But that's what was used before, so I just added it back as a safety fallback.

## Type of change

Please make your selection.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This change requires a new dependency
- [ ] Code Maintainability / comments
- [ ] Code Refactoring / future-proofing

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added pytest unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
