### PR TITLE
Fix binance stats

### DIFF
--- a/models/Stats.py
+++ b/models/Stats.py
@@ -22,7 +22,6 @@ class Stats():
         else:
             self.fiat_currency = self.app.getQuoteCurrency()
 
-        Logger.info(self.orders)
         # get buy/sell pairs (merge as necessary)
         last_order = None
         # pylint: disable=unused-variable

--- a/models/Stats.py
+++ b/models/Stats.py
@@ -22,6 +22,7 @@ class Stats():
         else:
             self.fiat_currency = self.app.getQuoteCurrency()
 
+        Logger.info(self.orders)
         # get buy/sell pairs (merge as necessary)
         last_order = None
         # pylint: disable=unused-variable
@@ -41,7 +42,7 @@ class Stats():
                 if self.app.exchange == 'coinbasepro':
                     amount = (row['filled'] * row['price']) - row['fees']
                 else:
-                    amount = row['size']
+                    amount = (float(row['filled']) * float(row['price'])) - row['fees']
                 if last_order == None: # first order is a sell (no pair)
                     continue
                 if last_order == 'buy':
@@ -116,9 +117,9 @@ class Stats():
                 d_market = '| ' + pair['market']
                 d_market = d_market + ' ' * (len(headers[1]) - len(d_market))
                 d_date = d_date + ' ' * (len(headers[2]) - len(d_date))
-                d_buy_size = '| ' + symbol + ' ' + '{:.2f}'.format(pair['buy']['size'])
+                d_buy_size = '| ' + symbol + ' ' + '{:.2f}'.format(float(pair['buy']['size']))
                 d_buy_size = d_buy_size + ' ' * (len(headers[3]) - len(d_buy_size))
-                d_sell_size = '| ' + symbol + ' ' + '{:.2f}'.format(pair['sell']['size'])
+                d_sell_size = '| ' + symbol + ' ' + '{:.2f}'.format(float(pair['sell']['size']))
                 d_sell_size = d_sell_size + ' ' * (len(headers[4]) - len(d_sell_size))
                 if pair['delta'] > 0:
                     d_delta = '| ' + symbol + ' {:.2f}'.format(pair['delta'])

--- a/models/exchange/binance/api.py
+++ b/models/exchange/binance/api.py
@@ -476,7 +476,7 @@ class AuthAPI(AuthAPIBase):
                 elif row.action == "buy":
                     return float(row.cummulativeQuoteQty) / float(row.filled)
                 elif row.action == "sell":
-                    return float(row.cummulativeQuoteQty) / float(row.size)
+                    return float(row.cummulativeQuoteQty) / float(row.filled)
                 else:
                     return row.price
 


### PR DESCRIPTION
## Description

--stats for binance was retuning incorrect percentage gains.

--statdetail was not working for binance as some values were sting instead of float

## Type of change

Please make your selection.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This change requires a new dependency
- [ ] Code Maintainability / comments
- [ ] Code Refactoring / future-proofing

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

## Checklist:

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added pytest unit tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings
