### PR TITLE
binance stats fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ Upgrade version:
 Upgrade library dependancies (if required):
 - python3 -m pip install -r requirements.txt -U
 
+## [3.2.10] - 2021-08-20
+
+### Changed
+
+-- 'stats' for binance was retuning incorrect percentage gains.
+-- 'statdetail' was not working for binance as some values were sting instead of float
+
 ## [3.2.9] - 2021-08-16
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![Docker](https://github.com/whittlem/pycryptobot/actions/workflows/container.yml/badge.svg)](https://github.com/whittlem/pycryptobot/actions/workflows/container.yml/badge.svg) [![Tests](https://github.com/whittlem/pycryptobot/actions/workflows/unit-tests.yml/badge.svg)](https://github.com/whittlem/pycryptobot/actions/workflows/unit-tests.yml/badge.svg)
 
-# Python Crypto Bot v3.2.9 (pycryptobot)
+# Python Crypto Bot v3.2.10 (pycryptobot)
 
 ## Join our chat on Telegram
 

--- a/models/Stats.py
+++ b/models/Stats.py
@@ -41,7 +41,7 @@ class Stats():
                 if self.app.exchange == 'coinbasepro':
                     amount = (row['filled'] * row['price']) - row['fees']
                 else:
-                    amount = row['size']
+                    amount = (float(row['filled']) * float(row['price'])) - row['fees']
                 if last_order == None: # first order is a sell (no pair)
                     continue
                 if last_order == 'buy':

--- a/models/exchange/binance/api.py
+++ b/models/exchange/binance/api.py
@@ -476,7 +476,7 @@ class AuthAPI(AuthAPIBase):
                 elif row.action == "buy":
                     return float(row.cummulativeQuoteQty) / float(row.filled)
                 elif row.action == "sell":
-                    return float(row.cummulativeQuoteQty) / float(row.size)
+                    return float(row.cummulativeQuoteQty) / float(row.filled)
                 else:
                     return row.price
 


### PR DESCRIPTION
## Description

-- 'stats' for binance was retuning incorrect percentage gains.
-- 'statdetail' was not working for binance as some values were sting instead of float

## Type of change

Please make your selection.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This change requires a new dependency
- [ ] Code Maintainability / comments
- [ ] Code Refactoring / future-proofing

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

## Checklist:

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added pytest unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings
