### PR TITLE
Binance US missing API return default fee

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ Upgrade version:
 Upgrade library dependancies (if required):
 - python3 -m pip install -r requirements.txt -U
 
-## [3.2.12] - 2021-08-23
+## [3.2.13] - 2021-08-23
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ Upgrade version:
 Upgrade library dependancies (if required):
 - python3 -m pip install -r requirements.txt -U
 
+## [3.2.12] - 2021-08-23
+
+### Changed
+
+-- Binance US is missing 'tradeFee' API endpoint, now returns default fee for this url
+
 ## [3.2.11] - 2021-08-22
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![Docker](https://github.com/whittlem/pycryptobot/actions/workflows/container.yml/badge.svg)](https://github.com/whittlem/pycryptobot/actions/workflows/container.yml/badge.svg) [![Tests](https://github.com/whittlem/pycryptobot/actions/workflows/unit-tests.yml/badge.svg)](https://github.com/whittlem/pycryptobot/actions/workflows/unit-tests.yml/badge.svg)
 
-# Python Crypto Bot v3.2.11 (pycryptobot)
+# Python Crypto Bot v3.2.12 (pycryptobot)
 
 ## Join our chat on Telegram
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![Docker](https://github.com/whittlem/pycryptobot/actions/workflows/container.yml/badge.svg)](https://github.com/whittlem/pycryptobot/actions/workflows/container.yml/badge.svg) [![Tests](https://github.com/whittlem/pycryptobot/actions/workflows/unit-tests.yml/badge.svg)](https://github.com/whittlem/pycryptobot/actions/workflows/unit-tests.yml/badge.svg)
 
-# Python Crypto Bot v3.2.12 (pycryptobot)
+# Python Crypto Bot v3.2.13 (pycryptobot)
 
 ## Join our chat on Telegram
 

--- a/models/exchange/binance/api.py
+++ b/models/exchange/binance/api.py
@@ -547,6 +547,10 @@ class AuthAPI(AuthAPIBase):
     def getTradeFee(self, market: str) -> float:
         """Retrieves the trade fees"""
 
+        # Binance US does not currently define "/sapi/v1/asset/tradeFee" in its API
+        if self._api_url == "https://api.binance.us":
+            return DEFAULT_TRADE_FEE_RATE
+
         try:
             # GET /sapi/v1/asset/tradeFee
             resp = self.authAPI(


### PR DESCRIPTION
## Description

Added a small change to return the default trade fee amount when the exchange is Binance US, since the API endpoint used on the non-US exchange is not defined in the US API

Fixes # (issue)

## Type of change

Please make your selection.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This change requires a new dependency
- [ ] Code Maintainability / comments
- [ ] Code Refactoring / future-proofing

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

## Checklist:

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added pytest unit tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings
