### PR TITLE
Buy near high configuration

### DIFF
--- a/models/PyCryptoBot.py
+++ b/models/PyCryptoBot.py
@@ -50,6 +50,7 @@ def parse_arguments():
     parser.add_argument('--sellpercent', type=int, help="percentage of base currency to sell")
     parser.add_argument('--lastaction', type=str, help="optionally set the last action (BUY, SELL)")
     parser.add_argument('--buymaxsize', type=float, help="maximum size on buy")
+    parser.add_argument('--buynearhighpcnt', type=float, help="optionally set the percent of high for buying near high (only if buynearhigh is\n't disabled)")
 
     # optional options
     parser.add_argument('--sellatresistance', action="store_true", help="sell at resistance or upper fibonacci band")
@@ -170,6 +171,7 @@ class PyCryptoBot():
         self.statgroup = None
         self.statstartdate = None
         self.statdetail = False
+        self.buynearhigh_pcnt = 3
 
         self.disablebullonly = False
         self.disablebuynearhigh = False
@@ -601,6 +603,9 @@ class PyCryptoBot():
 
     def sellLowerPcnt(self):
         return self.sell_lower_pcnt
+
+    def buyNearHighPcnt(self) -> float:
+        return self.buynearhigh_pcnt
 
     def trailingStopLoss(self):
         return self.trailing_stop_loss

--- a/models/PyCryptoBot.py
+++ b/models/PyCryptoBot.py
@@ -61,7 +61,7 @@ def parse_arguments():
 
     # disable defaults
     parser.add_argument('--disablebullonly', action="store_true", help="disable only buying in bull market")
-    parser.add_argument('--disablebuynearhigh', action="store_true", help="disable buy within 5 percent of high")
+    parser.add_argument('--disablebuynearhigh', action="store_true", help="disable buy within 3 percent of high")
     parser.add_argument('--disablebuymacd', action="store_true", help="disable macd buy signal")
     parser.add_argument('--disablebuyobv', action="store_true", help="disable obv buy signal")
     parser.add_argument('--disablebuyelderray', action="store_true", help="disable elder ray buy signal")

--- a/models/Strategy.py
+++ b/models/Strategy.py
@@ -27,8 +27,8 @@ class Strategy():
                 raise AttributeError(f"'{indicator}' not in Pandas dataframe")
 
         # buy signal exclusion (if disabled, do not buy within 3% of the dataframe close high)
-        if self.state.last_action == 'SELL' and self.app.disableBuyNearHigh() is True and (price > (self._df['close'].max() * 0.97)):
-            log_text = str(now) + ' | ' + self.app.getMarket() + ' | ' + self.app.printGranularity() + ' | Ignoring Buy Signal (price ' + str(price) + ' within 3% of high ' + str(self._df['close'].max()) + ')'
+        if self.state.last_action == 'SELL' and self.app.disableBuyNearHigh() is True and (price > (self._df['close'].max() * (1 - self.app.buyNearHighPcnt()/100))):
+            log_text = str(now) + ' | ' + self.app.getMarket() + ' | ' + self.app.printGranularity() + ' | Ignoring Buy Signal (price ' + str(price) + ' within ' +  str(self.app.buyNearHighPcnt()) + '% of high ' + str(self._df['close'].max()) + ')'
             Logger.warning(log_text)
 
             return False

--- a/models/config/default_parser.py
+++ b/models/config/default_parser.py
@@ -277,3 +277,10 @@ def defaultConfigParse(app, config):
                 app.buymaxsize = config['buymaxsize']
         else:
             raise TypeError('buymaxsize must be of type int or float')
+
+    if 'buynearhighpcnt' in config:
+        if isinstance(config['buynearhighpcnt'], (int, float)):
+            if config['buynearhighpcnt'] > 0:
+                app.buynearhigh_pcnt = config['buynearhighpcnt']
+        else:
+            raise TypeError('buynearhighpcnt must be of type int or float')


### PR DESCRIPTION
## Description

I think that the default 3% for the buyNearHigh option is too high for bot with a small granularity.
This MR add a new option (--buynearhighpcnt) to configure this percentage.
This maybe requires documentation update and/or an update of ConfigBuilder.py.

## Type of change

Please make your selection.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update
- [ ] This change requires a new dependency
- [ ] Code Maintainability / comments
- [ ] Code Refactoring / future-proofing

## How Has This Been Tested?

This has not been tested since it's a pretty straightforward change (and no so easy to test but be my guest)

## Checklist:

- [x] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added pytest unit tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
