### PR TITLE
switching to venv and bullseye

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ Upgrade version:
 Upgrade library dependencies (if required):
 - python3 -m pip install -r requirements.txt -U
 
+
+## [3.6.2] - 2021-09-13
+
+### Changed
+
+-- Updating Dockerfile to python:3.9-slim-bullseye
+-- switching to multistage venv Dockerfile and adding build-essentials in 1st stage to minimize Image size and build dependencies from source like numpy or statsmodels on arm64
+
 ## [3.6.0] - 2021-09-06
 
 ### Added

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,31 @@
-FROM python:3.9.1-slim-buster
+FROM python:3.9-slim-bullseye AS compile-image
+
+RUN DEBIAN_FRONTEND=noninteractive apt-get update && \
+    apt-get install -y \
+    build-essential && \
+    rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app
 
-COPY requirements.txt /app/
+RUN python -m venv /app
+# Make sure we use the virtualenv:
+ENV PATH="/app/bin:$PATH"
 
-RUN python -m pip install -U pip &&\
-      python -m pip install --no-cache-dir -r requirements.txt
+COPY requirements.txt .
 
-COPY . /app/
+RUN python -m pip install -U pip && \
+    python3 -m pip install --no-cache-dir -r requirements.txt
+
+COPY . /app
+
+FROM python:3.9-slim-bullseye
+
+WORKDIR /app
+
+COPY --from=compile-image /app /app
+
+# Make sure we use the virtualenv:
+ENV PATH="/app/bin:$PATH"
 
 # Pass parameters to the container run or mount your config.json into /app/
 ENTRYPOINT [ "python3", "-u", "pycryptobot.py" ]


### PR DESCRIPTION
## Description

- switching to multistage build and venv to build deps from source if necessary (e.g. numpy + statsmodel for arm64)
- adds image resiliency if dependencies missing
-  
Fixes # (issue)

#329 #419 on arm64
builds numpy + statsmodel from source


## Type of change

Please make your selection.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This change requires a new dependency
- [X] Code Maintainability / comments
- [X] Code Refactoring / future-proofing

## How Has This Been Tested?

build & run image

## Checklist:

- [ ] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added pytest unit tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [X] I have checked my code and corrected any misspellings

BR
Andre