### PR TITLE
Add Web App section to docker-compose.yaml

### DIFF
--- a/Dockerfile-websvc
+++ b/Dockerfile-websvc
@@ -1,0 +1,13 @@
+FROM python:3.9.1-slim-buster
+
+WORKDIR /app
+
+COPY requirements.txt /app/
+
+RUN python -m pip install -U pip &&\
+      python -m pip install --no-cache-dir -r requirements.txt
+
+COPY . /app/
+
+# Pass parameters to the container run or mount your config.json into /app/
+ENTRYPOINT [ "python3", "-u", "websvc.py" ]

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -47,3 +47,20 @@ services:
 #    deploy:
 #      restart_policy:
 #        condition: on-failure
+#
+# Uncomment to build and run Web Portal
+#  pycrypto-websvc:
+#      build:
+#        context: .
+#        dockerfile: Dockerfile-websvc
+#      container_name: pycrypto-websvc
+#      volumes:
+#        - ./market/:/app/market
+#        - /etc/localtime:/etc/localtime:ro
+#      ports:
+#        - 5000:5000
+#      environment:
+#        - PYTHONUNBUFFERED=1
+#      deploy:
+#        restart_policy:
+#          condition: on-failure

--- a/websvc.py
+++ b/websvc.py
@@ -26,7 +26,7 @@ parser.add_argument("--debug", action="store_true", help="enable debugging")
 args = parser.parse_args()
 
 # listen on local host
-http_host = "127.0.0.1"
+http_host = "0.0.0.0"
 if args.host is not None:
     p = re.compile(r"^\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}$")
     if p.match(args.host):


### PR DESCRIPTION
Add Capability to launch from Docker Compose, the WebApp function. This capability is commented-out by default.

## Description

Edit docker-compose.yaml to include a commented-out section for enabling WebApp function
Add Dockerfile-websvc to build Web App image if triggered by Docker Compose
Edit websvc.py to listen to all addresses (0.0.0.0) so that it works with Docker Compose. Otherwise we cannot point to it from outside Docker.

Fixes # (issue)

## Type of change

Please make your selection.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This change requires a new dependency
- [ ] Code Maintainability / comments
- [ ] Code Refactoring / future-proofing

## How Has This Been Tested?

Docker Compose v 1.29.2 on Ubuntu 21.04.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added pytest unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
