### PR TITLE
don't truncate close price

### DIFF
--- a/pycryptobot.py
+++ b/pycryptobot.py
@@ -482,7 +482,7 @@ def executeJob(
             # work with this precision. It should save a couple of `precision` uses, one for each `truncate()` call.
             truncate = functools.partial(_truncate, n=precision)
 
-            price_text = "Close: " + truncate(price)
+            price_text = "Close: " + str(price)
             ema_text = ""
             if app.disableBuyEMA() is False:
                 ema_text = app.compare(


### PR DESCRIPTION
## Description

in logs at analysis "Current Price:", "DF HIGH:" and "DF LOW:" is not truncated but "Close:" is. This leaves penny stocks doubtful to interpret.

## Type of change

Please make your selection.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This change requires a new dependency
- [ ] Code Maintainability / comments
- [ ] Code Refactoring / future-proofing

## How Has This Been Tested?

Tested with SHIB-USTD using a Coinbase Pro account
