### PR TITLE
Using enum instead of strings when comparing exchanges

### DIFF
--- a/models/AppState.py
+++ b/models/AppState.py
@@ -1,10 +1,13 @@
 """Application state class"""
 
-import sys
 import datetime
+import sys
+
 from numpy import array as np_array, min as np_min, ptp as np_ptp
+
 from models.PyCryptoBot import PyCryptoBot
 from models.TradingAccount import TradingAccount
+from models.exchange.ExchangesEnum import Exchange
 from models.exchange.binance import AuthAPI as BAuthAPI
 from models.exchange.coinbase_pro import AuthAPI as CAuthAPI
 from models.exchange.kucoin import AuthAPI as KAuthAPI
@@ -13,21 +16,21 @@ from models.helper.LogHelper import Logger
 
 class AppState:
     def __init__(self, app: PyCryptoBot, account: TradingAccount) -> None:
-        if app.getExchange() == "binance":
+        if app.getExchange() == Exchange.BINANCE.value:
             self.api = BAuthAPI(
                 app.getAPIKey(),
                 app.getAPISecret(),
                 app.getAPIURL(),
                 recv_window=app.getRecvWindow(),
             )
-        elif app.getExchange() == "coinbasepro":
+        elif app.getExchange() == Exchange.COINBASEPRO.value:
             self.api = CAuthAPI(
                 app.getAPIKey(),
                 app.getAPISecret(),
                 app.getAPIPassphrase(),
                 app.getAPIURL(),
             )
-        elif app.getExchange() == "kucoin":
+        elif app.getExchange() == Exchange.KUCOIN.value:
             self.api = KAuthAPI(
                 app.getAPIKey(),
                 app.getAPISecret(),
@@ -70,7 +73,7 @@ class AppState:
 
     def minimumOrderBase(self):
         self.app.insufficientfunds = False
-        if self.app.getExchange() == "binance":
+        if self.app.getExchange() == Exchange.BINANCE.value:
             df = self.api.getMarketInfoFilters(self.app.getMarket())
 
             if len(df) > 0:
@@ -95,7 +98,7 @@ class AppState:
 
                 return
 
-        elif self.app.getExchange() == "coinbasepro":
+        elif self.app.getExchange() == Exchange.COINBASEPRO.value:
             product = self.api.authAPI("GET", f"products/{self.app.getMarket()}")
             if len(product) == 0:
                 sys.tracebacklimit = 0
@@ -124,13 +127,13 @@ class AppState:
             raise Exception(
                 f"Insufficient Base Funds! (Actual: {base}, Minimum: {base_min})"
             )
-        elif self.app.getExchange() == "kucoin":
+        elif self.app.getExchange() == Exchange.KUCOIN.value:
             # added for Kucoin last order check below
             return True
             
     def minimumOrderQuote(self):
         self.app.insufficientfunds = False
-        if self.app.getExchange() == "binance":
+        if self.app.getExchange() == Exchange.BINANCE.value:
             df = self.api.getMarketInfoFilters(self.app.getMarket())
 
             if len(df) > 0:
@@ -159,7 +162,7 @@ class AppState:
                 sys.tracebacklimit = 0
                 raise Exception(f"Market not found! ({self.app.getMarket()})")
 
-        elif self.app.getExchange() == "coinbasepro":
+        elif self.app.getExchange() == Exchange.COINBASEPRO.value:
             product = self.api.authAPI("GET", f"products/{self.app.getMarket()}")
             if len(product) == 0:
                 sys.tracebacklimit = 0
@@ -223,7 +226,7 @@ class AppState:
                 )
 
                 # binance orders do not show fees
-                if self.app.getExchange() == "coinbasepro" or self.app.getExchange() == "kucoin":
+                if self.app.getExchange() == Exchange.COINBASEPRO.value or self.app.getExchange() == Exchange.KUCOIN.value:
                     self.last_buy_fee = float(
                         last_order[last_order.action == "buy"]["fees"]
                     )
@@ -255,7 +258,7 @@ class AppState:
                 order_pairs
             )
 
-            if self.app.getExchange() == "kucoin" and self.minimumOrderBase():
+            if self.app.getExchange() == Exchange.KUCOIN.value and self.minimumOrderBase():
                 self.last_action = "WAIT"
                 Logger.warning('Kucoin temporary state set to "WAIT".') 
             elif order_pairs_normalised[0] < order_pairs_normalised[1]:

--- a/models/BotConfig.py
+++ b/models/BotConfig.py
@@ -1,5 +1,4 @@
 import argparse
-import fileinput
 import json
 import os
 import re
@@ -9,6 +8,7 @@ import yaml
 from yaml.constructor import ConstructorError
 from yaml.scanner import ScannerError
 
+from models.ConfigBuilder import ConfigBuilder
 from models.chat import Telegram
 from models.config import (
     binanceConfigParser,
@@ -17,8 +17,8 @@ from models.config import (
     dummyConfigParser,
     loggerConfigParser,
 )
-from models.ConfigBuilder import ConfigBuilder
 from models.helper.LogHelper import Logger
+from models.exchange.ExchangesEnum import Exchange
 
 
 class BotConfig:
@@ -161,16 +161,16 @@ class BotConfig:
         ) = self._set_default_api_info(self.exchange)
 
         if self.config_provided:
-            if self.exchange == "coinbasepro" and "coinbasepro" in self.config:
+            if self.exchange == Exchange.COINBASEPRO.value and "coinbasepro" in self.config:
                 coinbaseProConfigParser(self, self.config["coinbasepro"], self.cli_args)
 
-            elif self.exchange == "binance" and "binance" in self.config:
+            elif self.exchange == Exchange.BINANCE.value and "binance" in self.config:
                 binanceConfigParser(self, self.config["binance"], self.cli_args)
 
-            elif self.exchange == "kucoin" and "kucoin" in self.config:
+            elif self.exchange == Exchange.KUCOIN.value and "kucoin" in self.config:
                 kucoinConfigParser(self, self.config["kucoin"], self.cli_args)
 
-            elif self.exchange == "dummy" and "dummy" in self.config:
+            elif self.exchange == Exchange.DUMMY.value and "dummy" in self.config:
                 dummyConfigParser(self, self.config["dummy"], self.cli_args)
 
             if (
@@ -194,9 +194,9 @@ class BotConfig:
                 self.logfile == "/dev/null"
 
         else:
-            if self.exchange == "binance":
+            if self.exchange == Exchange.BINANCE.value:
                 binanceConfigParser(self, None, self.cli_args)
-            elif self.exchange == "kucoin":
+            elif self.exchange == Exchange.KUCOIN.value:
                 kucoinConfigParser(self, None, self.cli_args)
             else:
                 coinbaseProConfigParser(self, None, self.cli_args)

--- a/models/TradingAccount.py
+++ b/models/TradingAccount.py
@@ -1,10 +1,13 @@
 """Live or test trading account"""
 
 import re
+from datetime import datetime
+
 import numpy as np
 import pandas as pd
-from datetime import datetime
+
 from models.PyCryptoBot import truncate
+from models.exchange.ExchangesEnum import Exchange
 from models.exchange.binance import AuthAPI as BAuthAPI
 from models.exchange.coinbase_pro import AuthAPI as CBAuthAPI
 from models.exchange.kucoin import AuthAPI as KAuthAPI
@@ -56,15 +59,15 @@ class TradingAccount:
         market : str
             market to check
         """
-        if self.app.getExchange() == "coinbasepro" and market != "":
+        if self.app.getExchange() == Exchange.COINBASEPRO.value and market != "":
             p = re.compile(r"^[1-9A-Z]{2,5}\-[1-9A-Z]{2,5}$")
             if not p.match(market):
                 raise TypeError("Coinbase Pro market is invalid.")
-        elif self.app.getExchange() == "binance":
+        elif self.app.getExchange() == Exchange.BINANCE.value:
             p = re.compile(r"^[A-Z]{5,12}$")
             if not p.match(market):
                 raise TypeError("Binance market is invalid.")
-        elif self.app.getExchange() == "kucoin":
+        elif self.app.getExchange() == Exchange.KUCOIN.value:
             p = re.compile(r"^[1-9A-Z]{2,5}\-[1-9A-Z]{2,5}$")
             if not p.match(market):
                 raise TypeError("Kucoin market is invalid.")
@@ -94,7 +97,7 @@ class TradingAccount:
         if not status in ["open", "pending", "done", "active", "all", "filled"]:
             raise ValueError("Invalid order status.")
 
-        if self.app.getExchange() == "binance":
+        if self.app.getExchange() == Exchange.BINANCE.value:
             if self.mode == "live":
                 # if config is provided and live connect to Binance account portfolio
                 model = BAuthAPI(
@@ -113,7 +116,7 @@ class TradingAccount:
                 else:
                     return self.orders[self.orders["market"] == market]
 
-        if self.app.getExchange() == 'kucoin':
+        if self.app.getExchange() == Exchange.KUCOIN.value:
             if self.mode == 'live':
                 # if config is provided and live connect to Kucoin account portfolio
                 model = KAuthAPI(
@@ -131,7 +134,7 @@ class TradingAccount:
                 else:
                     return self.orders[self.orders['market'] == market]
 
-        if self.app.getExchange() == "coinbasepro":
+        if self.app.getExchange() == Exchange.COINBASEPRO.value:
             if self.mode == "live":
                 # if config is provided and live connect to Coinbase Pro account portfolio
                 model = CBAuthAPI(
@@ -152,7 +155,7 @@ class TradingAccount:
                         return self.orders[self.orders["market"] == market]
                     else:
                         return pd.DataFrame()
-        if self.app.getExchange() == "dummy":
+        if self.app.getExchange() == Exchange.DUMMY.value:
             return self.orders[
                 [
                     "created_at",
@@ -176,7 +179,7 @@ class TradingAccount:
             Filters orders by currency
         """
 
-        if self.app.getExchange() == 'kucoin':
+        if self.app.getExchange() == Exchange.KUCOIN.value:
             if self.mode == 'live':
                 model = KAuthAPI(self.app.getAPIKey(), self.app.getAPISecret(), self.app.getAPIPassphrase(), self.app.getAPIURL())
                 df = model.getAccounts()
@@ -204,7 +207,7 @@ class TradingAccount:
                     # retrieve all balances
                     return self.balance
                 else:
-                    if self.app.getExchange() == 'kucoin':
+                    if self.app.getExchange() == Exchange.KUCOIN.value:
                         self.balance = self.balance.replace('QUOTE', currency)
                     else:
                         # replace QUOTE and BASE placeholders
@@ -230,7 +233,7 @@ class TradingAccount:
                         else:
                             return float(truncate(float(df[df['currency'] == currency]['available'].values[0]), 4))
 
-        elif self.app.getExchange() == "binance":
+        elif self.app.getExchange() == Exchange.BINANCE.value:
             if self.mode == "live":
                 model = BAuthAPI(
                     self.app.getAPIKey(),
@@ -285,7 +288,7 @@ class TradingAccount:
                     # retrieve all balances
                     return self.balance
                 else:
-                    if self.app.getExchange() == "binance":
+                    if self.app.getExchange() == Exchange.BINANCE.value:
                         self.balance = self.balance.replace("QUOTE", currency)
                     else:
                         # replace QUOTE and BASE placeholders
@@ -331,7 +334,7 @@ class TradingAccount:
                                 )
                             )
 
-        elif self.app.getExchange() == "coinbasepro":
+        elif self.app.getExchange() == Exchange.COINBASEPRO.value:
             if self.mode == "live":
                 # if config is provided and live connect to Coinbase Pro account portfolio
                 model = CBAuthAPI(
@@ -735,13 +738,13 @@ class TradingAccount:
         self._checkMarketSyntax(market)
 
         if self.mode == "live":
-            if self.app.getExchange() == "coinbasepro":
+            if self.app.getExchange() == Exchange.COINBASEPRO.value:
                 # retrieve orders from live Coinbase Pro account portfolio
                 df = self.getOrders(market, "", "done")
-            elif self.app.getExchange() == "binance":
+            elif self.app.getExchange() == Exchange.BINANCE.value:
                 # retrieve orders from live Binance account portfolio
                 df = self.getOrders(market, "", "done")
-            elif self.app.getExchange() == 'kucoin':
+            elif self.app.getExchange() == Exchange.KUCOIN.value:
                 # retrieve orders from live Kucoin account portfolio
                 df = self.getOrders(market, '', 'done')
             else:

--- a/models/exchange/ExchangesEnum.py
+++ b/models/exchange/ExchangesEnum.py
@@ -1,0 +1,8 @@
+from enum import Enum
+
+
+class Exchange(Enum):
+    COINBASEPRO = "coinbasepro"
+    BINANCE = "binance"
+    KUCOIN = "kucoin"
+    DUMMY = "dummy"

--- a/pycryptobot.py
+++ b/pycryptobot.py
@@ -24,6 +24,7 @@ from models.Trading import TechnicalAnalysis
 from models.TradingAccount import TradingAccount
 from views.TradingGraphs import TradingGraphs
 from models.helper.TextBoxHelper import TextBox
+from models.exchange.ExchangesEnum import Exchange
 from models.exchange.binance import WebSocketClient as BWebSocketClient
 from models.exchange.coinbase_pro import WebSocketClient as CWebSocketClient
 from models.helper.TelegramBotHelper import TelegramBotHelper
@@ -276,7 +277,7 @@ def executeJob(
         list(map(s.cancel, s.queue))
         s.enter(5, 1, executeJob, (sc, _app, _state, _technical_analysis, _websocket))
 
-    if _app.getExchange() == "binance" and _app.getGranularity() == 86400:
+    if _app.getExchange() == Exchange.BINANCE.value and _app.getGranularity() == 86400:
         if len(df) < 250:
             # data frame should have 250 rows, if not retry
             Logger.error(f"error: data frame length is < 250 ({str(len(df))})")
@@ -432,8 +433,8 @@ def executeJob(
                         _state.last_buy_price = exchange_last_buy["price"]
 
                     if (
-                        _app.getExchange() == "coinbasepro"
-                        or _app.getExchange() == "kucoin"
+                        _app.getExchange() == Exchange.COINBASEPRO.value
+                        or _app.getExchange() == Exchange.COINBASEPRO.value
                     ):
                         if _state.last_buy_fee != exchange_last_buy["fee"]:
                             _state.last_buy_fee = exchange_last_buy["fee"]
@@ -1631,9 +1632,9 @@ def executeJob(
         # if live but not websockets
         if not _app.disableTracker() and _app.isLive() and not _app.enableWebsocket():
             # update order tracker csv
-            if _app.getExchange() == "binance":
+            if _app.getExchange() == Exchange.BINANCE.value:
                 account.saveTrackerCSV(_app.getMarket())
-            elif _app.getExchange() == "coinbasepro" or _app.getExchange() == "kucoin":
+            elif _app.getExchange() == Exchange.COINBASEPRO.value or _app.getExchange() == Exchange.COINBASEPRO.value:
                 account.saveTrackerCSV()
 
         if _app.isSimulation():
@@ -1675,19 +1676,19 @@ def executeJob(
 def main():
     try:
         message = "Starting "
-        if app.getExchange() == "coinbasepro":
+        if app.getExchange() == Exchange.COINBASEPRO.value:
             message += "Coinbase Pro bot"
             if app.enableWebsocket() and not app.isSimulation():
                 print("Opening websocket to Coinbase Pro...")
                 _websocket = CWebSocketClient([app.getMarket()], app.getGranularity())
                 _websocket.start()
-        elif app.getExchange() == "binance":
+        elif app.getExchange() == Exchange.BINANCE.value:
             message += "Binance bot"
             if app.enableWebsocket() and not app.isSimulation():
                 print("Opening websocket to Binance...")
                 _websocket = BWebSocketClient([app.getMarket()], app.getGranularity())
                 _websocket.start()
-        elif app.getExchange() == "kucoin":
+        elif app.getExchange() == Exchange.COINBASEPRO.value:
             message += "Kucoin bot"
 
         smartSwitchStatus = "enabled" if app.getSmartSwitch() else "disabled"

--- a/tests/unit_tests/test_exchange_enum.py
+++ b/tests/unit_tests/test_exchange_enum.py
@@ -1,0 +1,36 @@
+import sys
+
+import pytest
+
+from models.exchange.ExchangesEnum import Exchange
+
+sys.path.append('.')
+
+
+def test_enum_value_is_correct_for_binance():
+    assert Exchange.BINANCE.value == "binance"
+
+
+def test_enum_value_is_correct_for_coinbasepro():
+    assert Exchange.COINBASEPRO.value == "coinbasepro"
+
+
+def test_enum_value_is_correct_for_kucoin():
+    assert Exchange.KUCOIN.value == "kucoin"
+
+
+def test_enum_value_is_correct_for_dummy():
+    assert Exchange.DUMMY.value == "dummy"
+
+
+def test_converting_string_to_enum():
+    assert Exchange("binance") == Exchange.BINANCE
+    assert Exchange("coinbasepro") == Exchange.COINBASEPRO
+    assert Exchange("kucoin") == Exchange.KUCOIN
+
+
+def test_exception_thrown_when_invalid_value():
+    with pytest.raises(ValueError) as exc_info:
+        Exchange("xxx")
+    assert exc_info.type is ValueError
+    assert exc_info.value.args[0] == "'xxx' is not a valid Exchange"


### PR DESCRIPTION
## Description

Reading the code, I noticed a lot of places where exchanges were declared as literal strings, so I decided to create an enum for the exchanges so they could be in a centralized location.  This will decrease the chances of a bug due to a typo.

## Type of change

Please make your selection.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This change requires a new dependency
- [x] Code Maintainability / comments
- [x] Code Refactoring / future-proofing

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

## Checklist:

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added pytest unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
