### PR TITLE
Kucoin fix for multiple buys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Upgrade version:
 Upgrade library dependencies (if required):
 - python3 -m pip install -r requirements.txt -U
 
+## [4.3.2] - 2021-11-02
+
+- fix for Kucoin multiple buys on same traded pair when API error occurs
+
 ## [4.3.1] - 2021-10-28
 
 - fix for Kucoin margin calculation

--- a/models/AppState.py
+++ b/models/AppState.py
@@ -1,10 +1,13 @@
 """Application state class"""
 
-import sys
 import datetime
+import sys
+
 from numpy import array as np_array, min as np_min, ptp as np_ptp
+
 from models.PyCryptoBot import PyCryptoBot
 from models.TradingAccount import TradingAccount
+from models.exchange.ExchangesEnum import Exchange
 from models.exchange.binance import AuthAPI as BAuthAPI
 from models.exchange.coinbase_pro import AuthAPI as CAuthAPI
 from models.exchange.kucoin import AuthAPI as KAuthAPI
@@ -13,21 +16,21 @@ from models.helper.LogHelper import Logger
 
 class AppState:
     def __init__(self, app: PyCryptoBot, account: TradingAccount) -> None:
-        if app.getExchange() == "binance":
+        if app.getExchange() == Exchange.BINANCE.value:
             self.api = BAuthAPI(
                 app.getAPIKey(),
                 app.getAPISecret(),
                 app.getAPIURL(),
                 recv_window=app.getRecvWindow(),
             )
-        elif app.getExchange() == "coinbasepro":
+        elif app.getExchange() == Exchange.COINBASEPRO.value:
             self.api = CAuthAPI(
                 app.getAPIKey(),
                 app.getAPISecret(),
                 app.getAPIPassphrase(),
                 app.getAPIURL(),
             )
-        elif app.getExchange() == "kucoin":
+        elif app.getExchange() == Exchange.KUCOIN.value:
             self.api = KAuthAPI(
                 app.getAPIKey(),
                 app.getAPISecret(),
@@ -70,7 +73,7 @@ class AppState:
 
     def minimumOrderBase(self):
         self.app.insufficientfunds = False
-        if self.app.getExchange() == "binance":
+        if self.app.getExchange() == Exchange.BINANCE.value:
             df = self.api.getMarketInfoFilters(self.app.getMarket())
 
             if len(df) > 0:
@@ -95,7 +98,7 @@ class AppState:
 
                 return
 
-        elif self.app.getExchange() == "coinbasepro":
+        elif self.app.getExchange() == Exchange.COINBASEPRO.value:
             product = self.api.authAPI("GET", f"products/{self.app.getMarket()}")
             if len(product) == 0:
                 sys.tracebacklimit = 0
@@ -130,7 +133,7 @@ class AppState:
             
     def minimumOrderQuote(self):
         self.app.insufficientfunds = False
-        if self.app.getExchange() == "binance":
+        if self.app.getExchange() == Exchange.BINANCE.value:
             df = self.api.getMarketInfoFilters(self.app.getMarket())
 
             if len(df) > 0:
@@ -159,7 +162,7 @@ class AppState:
                 sys.tracebacklimit = 0
                 raise Exception(f"Market not found! ({self.app.getMarket()})")
 
-        elif self.app.getExchange() == "coinbasepro":
+        elif self.app.getExchange() == Exchange.COINBASEPRO.value:
             product = self.api.authAPI("GET", f"products/{self.app.getMarket()}")
             if len(product) == 0:
                 sys.tracebacklimit = 0
@@ -226,7 +229,7 @@ class AppState:
                 )
 
                 # binance orders do not show fees
-                if self.app.getExchange() == "coinbasepro" or self.app.getExchange() == "kucoin":
+                if self.app.getExchange() == Exchange.COINBASEPRO.value or self.app.getExchange() == Exchange.KUCOIN.value:
                     self.last_buy_fee = float(
                         last_order[last_order.action == "buy"]["fees"]
                     )
@@ -259,7 +262,7 @@ class AppState:
             )
 
             # If Kucoin returns emoty response, on a shared trading account, could multiple buy same pair
-            if self.app.getExchange() == "kucoin" and self.minimumOrderBase() and self.minimumOrderQuote():
+            if self.app.getExchange() == Exchange.KUCOIN.value and self.minimumOrderBase() and self.minimumOrderQuote():
                 if self.last_action == "BUY":
                     return
                 else:

--- a/models/Strategy.py
+++ b/models/Strategy.py
@@ -70,6 +70,12 @@ class Strategy:
 
             return False
 
+        ## if last_action was set to "WAIT" due to an API problem, do not buy
+        if ( self.state.last_action == "WAIT"):
+            return False
+            log_text = (f"{str(now)} | {self.app.getMarket()} | {self.app.printGranularity()} | last_action is WAIT, do not buy yet")
+            Logger.warning(log_text)
+
         # if EMA, MACD are disabled, do not buy
         if self.app.disableBuyEMA() and self.app.disableBuyMACD():
             log_text = (f"{str(now)} | {self.app.getMarket()} | {self.app.printGranularity()} | EMA, MACD indicators are disabled")


### PR DESCRIPTION
## Description

When the API would return empty or incorrect data, bot could improperly evaluate last action as a sell.  Added some additional checks to the Kucoin code that would prevent that and a WAIT state check in Strategy.py that could be reference by other exchange APIs or other code for a similar reason.  

Fixes # (issue)

## Type of change

Please make your selection.

- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This change requires a new dependency
- [ x] Code Maintainability / comments
- [ ] Code Refactoring / future-proofing

## How Has This Been Tested?

Running multiple bots myself for more than 2 days without issue occurring again.  Previously would happen frequently when bot process restarts or gets a "Too many requests" error.

## Checklist:

- [ x] My code follows the style guidelines of this project
- [ x] I have performed a self-review of my own code
- [ x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ x] My changes generate no new warnings
- [ ] I have added pytest unit tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ x] I have checked my code and corrected any misspellings
