### PR TITLE
Finishing exchange migration to enum

### DIFF
--- a/models/AppState.py
+++ b/models/AppState.py
@@ -16,21 +16,21 @@ from models.helper.LogHelper import Logger
 
 class AppState:
     def __init__(self, app: PyCryptoBot, account: TradingAccount) -> None:
-        if app.getExchange() == Exchange.BINANCE.value:
+        if app.getExchange() == Exchange.BINANCE:
             self.api = BAuthAPI(
                 app.getAPIKey(),
                 app.getAPISecret(),
                 app.getAPIURL(),
                 recv_window=app.getRecvWindow(),
             )
-        elif app.getExchange() == Exchange.COINBASEPRO.value:
+        elif app.getExchange() == Exchange.COINBASEPRO:
             self.api = CAuthAPI(
                 app.getAPIKey(),
                 app.getAPISecret(),
                 app.getAPIPassphrase(),
                 app.getAPIURL(),
             )
-        elif app.getExchange() == Exchange.KUCOIN.value:
+        elif app.getExchange() == Exchange.KUCOIN:
             self.api = KAuthAPI(
                 app.getAPIKey(),
                 app.getAPISecret(),
@@ -73,7 +73,7 @@ class AppState:
 
     def minimumOrderBase(self):
         self.app.insufficientfunds = False
-        if self.app.getExchange() == Exchange.BINANCE.value:
+        if self.app.getExchange() == Exchange.BINANCE:
             df = self.api.getMarketInfoFilters(self.app.getMarket())
 
             if len(df) > 0:
@@ -98,7 +98,7 @@ class AppState:
 
                 return
 
-        elif self.app.getExchange() == Exchange.COINBASEPRO.value:
+        elif self.app.getExchange() == Exchange.COINBASEPRO:
             product = self.api.authAPI("GET", f"products/{self.app.getMarket()}")
             if len(product) == 0:
                 sys.tracebacklimit = 0
@@ -107,7 +107,7 @@ class AppState:
             base = float(self.account.basebalance)
             base_min = float(product["base_min_size"])
 
-        elif self.app.getExchange() == 'kucoin':
+        elif self.app.getExchange() == Exchange.KUCOIN:
             resp = self.api.authAPI('GET', f'api/v1/symbols')
             product = resp[resp['symbol'] == self.app.getMarket()]
             if len(product) == 0:
@@ -127,13 +127,13 @@ class AppState:
             raise Exception(
                 f"Insufficient Base Funds! (Actual: {base}, Minimum: {base_min})"
             )
-        elif self.app.getExchange() == Exchange.KUCOIN.value:
+        elif self.app.getExchange() == Exchange.KUCOIN:
             # added for Kucoin last order check below
             return True
             
     def minimumOrderQuote(self):
         self.app.insufficientfunds = False
-        if self.app.getExchange() == Exchange.BINANCE.value:
+        if self.app.getExchange() == Exchange.BINANCE:
             df = self.api.getMarketInfoFilters(self.app.getMarket())
 
             if len(df) > 0:
@@ -162,7 +162,7 @@ class AppState:
                 sys.tracebacklimit = 0
                 raise Exception(f"Market not found! ({self.app.getMarket()})")
 
-        elif self.app.getExchange() == Exchange.COINBASEPRO.value:
+        elif self.app.getExchange() == Exchange.COINBASEPRO:
             product = self.api.authAPI("GET", f"products/{self.app.getMarket()}")
             if len(product) == 0:
                 sys.tracebacklimit = 0
@@ -174,7 +174,7 @@ class AppState:
             quote = float(self.account.quotebalance)
             base_min = float(product["base_min_size"])
 
-        elif self.app.getExchange() == 'kucoin':
+        elif self.app.getExchange() == Exchange.KUCOIN:
             resp = self.api.authAPI('GET', f'api/v1/symbols')
             product = resp[resp['symbol'] == self.app.getMarket()]
             if len(product) == 0:
@@ -226,7 +226,7 @@ class AppState:
                 )
 
                 # binance orders do not show fees
-                if self.app.getExchange() == Exchange.COINBASEPRO.value or self.app.getExchange() == Exchange.KUCOIN.value:
+                if self.app.getExchange() == Exchange.COINBASEPRO or self.app.getExchange() == Exchange.KUCOIN:
                     self.last_buy_fee = float(
                         last_order[last_order.action == "buy"]["fees"]
                     )
@@ -258,7 +258,7 @@ class AppState:
                 order_pairs
             )
 
-            if self.app.getExchange() == Exchange.KUCOIN.value and self.minimumOrderBase():
+            if self.app.getExchange() == Exchange.KUCOIN and self.minimumOrderBase():
                 self.last_action = "WAIT"
                 Logger.warning('Kucoin temporary state set to "WAIT".') 
             elif order_pairs_normalised[0] < order_pairs_normalised[1]:

--- a/models/BotConfig.py
+++ b/models/BotConfig.py
@@ -17,8 +17,8 @@ from models.config import (
     dummyConfigParser,
     loggerConfigParser,
 )
-from models.helper.LogHelper import Logger
 from models.exchange.ExchangesEnum import Exchange
+from models.helper.LogHelper import Logger
 
 
 class BotConfig:
@@ -162,17 +162,17 @@ class BotConfig:
         ) = self._set_default_api_info(self.exchange)
 
         if self.config_provided:
-            if self.exchange == Exchange.COINBASEPRO.value and "coinbasepro" in self.config:
-                coinbaseProConfigParser(self, self.config["coinbasepro"], self.cli_args)
+            if self.exchange == Exchange.COINBASEPRO and self.exchange.value in self.config:
+                coinbaseProConfigParser(self, self.config[self.exchange.value], self.cli_args)
 
-            elif self.exchange == Exchange.BINANCE.value and "binance" in self.config:
-                binanceConfigParser(self, self.config["binance"], self.cli_args)
+            elif self.exchange == Exchange.BINANCE and self.exchange.value in self.config:
+                binanceConfigParser(self, self.config[self.exchange.value], self.cli_args)
 
-            elif self.exchange == Exchange.KUCOIN.value and "kucoin" in self.config:
-                kucoinConfigParser(self, self.config["kucoin"], self.cli_args)
+            elif self.exchange == Exchange.KUCOIN and self.exchange.value in self.config:
+                kucoinConfigParser(self, self.config[self.exchange.value], self.cli_args)
 
-            elif self.exchange == Exchange.DUMMY.value and "dummy" in self.config:
-                dummyConfigParser(self, self.config["dummy"], self.cli_args)
+            elif self.exchange == Exchange.DUMMY and self.exchange.value in self.config:
+                dummyConfigParser(self, self.config[self.exchange.value], self.cli_args)
 
             if (
                 not self.disabletelegram
@@ -195,9 +195,9 @@ class BotConfig:
                 self.logfile == "/dev/null"
 
         else:
-            if self.exchange == Exchange.BINANCE.value:
+            if self.exchange == Exchange.BINANCE:
                 binanceConfigParser(self, None, self.cli_args)
-            elif self.exchange == Exchange.KUCOIN.value:
+            elif self.exchange == Exchange.KUCOIN:
                 kucoinConfigParser(self, None, self.cli_args)
             else:
                 coinbaseProConfigParser(self, None, self.cli_args)
@@ -214,32 +214,23 @@ class BotConfig:
             consoleloglevel=self.consoleloglevel,
         )
 
-    def _set_exchange(self, exchange: str = None) -> str:
-        valid_exchanges = ["coinbasepro", "binance", "kucoin", "dummy"]
+    def _set_exchange(self, exchange: str = None) -> Exchange:
 
         if self.cli_args["exchange"] is not None:
-            exchange = self.cli_args["exchange"]
-
-        if exchange and exchange in valid_exchanges:
-            return exchange
+            exchange = Exchange(self.cli_args["exchange"])
 
         if not exchange:
-            if ("coinbasepro" or "api_pass") in self.config:
-                exchange = "coinbasepro"
-            elif "binance" in self.config:
-                exchange = "binance"
-            elif "kucoin" in self.config:
-                exchange = "kucoin"
+            if (Exchange.COINBASEPRO.value or "api_pass") in self.config:
+                exchange = Exchange.COINBASEPRO
+            elif Exchange.BINANCE.value in self.config:
+                exchange = Exchange.BINANCE
+            elif Exchange.KUCOIN.value in self.config:
+                exchange = Exchange.KUCOIN
             else:
-                exchange = "dummy"
-
-        if exchange not in valid_exchanges:
-            raise TypeError(
-                f"Invalid exchange: {exchange}. Valid choices: {valid_exchanges}"
-            )
+                exchange = Exchange.DUMMY
         return exchange
 
-    def _set_default_api_info(self, exchange: str = "dummy") -> tuple:
+    def _set_default_api_info(self, exchange: Exchange = Exchange.DUMMY) -> tuple:
         conf = {
             "binance": {
                 "api_url": "https://api.binance.com",
@@ -271,11 +262,11 @@ class BotConfig:
             },
         }
         return (
-            conf[exchange]["api_url"],
-            conf[exchange]["api_key"],
-            conf[exchange]["api_secret"],
-            conf[exchange]["api_passphrase"],
-            conf[exchange]["market"],
+            conf[exchange.value]["api_url"],
+            conf[exchange.value]["api_key"],
+            conf[exchange.value]["api_secret"],
+            conf[exchange.value]["api_passphrase"],
+            conf[exchange.value]["market"],
         )
 
     def getVersionFromREADME(self) -> str:

--- a/models/PyCryptoBot.py
+++ b/models/PyCryptoBot.py
@@ -64,7 +64,7 @@ def truncate(f: Union[int, float], n: Union[int, float]) -> str:
 
 
 class PyCryptoBot(BotConfig):
-    def __init__(self, config_file: str = None, exchange: str = None):
+    def __init__(self, config_file: str = None, exchange: Exchange = None):
         self.config_file = config_file or "config.json"
         self.exchange = exchange
         super(PyCryptoBot, self).__init__(
@@ -95,9 +95,9 @@ class PyCryptoBot(BotConfig):
         try:
             config = json.loads(open(self.config_file, "r").read())
 
-            if self.exchange in config:
-                if "config" in config[self.exchange]:
-                    return config[self.exchange]["config"]
+            if self.exchange.value in config:
+                if "config" in config[self.exchange.value]:
+                    return config[self.exchange.value]["config"]
                 else:
                     return {}
             else:
@@ -107,9 +107,9 @@ class PyCryptoBot(BotConfig):
 
     def _isCurrencyValid(self, currency):
         if (
-            self.exchange == Exchange.COINBASEPRO.value
-            or self.exchange == Exchange.BINANCE.value
-            or self.exchange == Exchange.KUCOIN.value
+            self.exchange == Exchange.COINBASEPRO
+            or self.exchange == Exchange.BINANCE
+            or self.exchange == Exchange.KUCOIN
         ):
             p = re.compile(r"^[1-9A-Z]{2,5}$")
             return p.match(currency)
@@ -117,10 +117,10 @@ class PyCryptoBot(BotConfig):
         return False
 
     def _isMarketValid(self, market):
-        if self.exchange == Exchange.COINBASEPRO.value or self.exchange == Exchange.KUCOIN.value:
+        if self.exchange == Exchange.COINBASEPRO or self.exchange == Exchange.KUCOIN:
             p = re.compile(r"^[1-9A-Z]{2,5}\-[1-9A-Z]{2,5}$")
             return p.match(market)
-        elif self.exchange == Exchange.BINANCE.value:
+        elif self.exchange == Exchange.BINANCE:
             p = re.compile(r"^[A-Z0-9]{6,12}$")
             if p.match(market):
                 return True
@@ -140,7 +140,7 @@ class PyCryptoBot(BotConfig):
     def getTradesFile(self):
         return self.tradesfile
 
-    def getExchange(self):
+    def getExchange(self) -> Exchange:
         return self.exchange
 
     def getChatClient(self):
@@ -165,7 +165,7 @@ class PyCryptoBot(BotConfig):
         return self.quote_currency
 
     def getMarket(self):
-        if self.exchange == Exchange.BINANCE.value:
+        if self.exchange == Exchange.BINANCE:
             formatCheck = self.market.split("-") if self.market.find("-") != -1 else ""
             if not formatCheck == "":
                 self.base_currency = formatCheck[0]
@@ -192,15 +192,15 @@ class PyCryptoBot(BotConfig):
             return df.tail(1)
 
     def printGranularity(self) -> str:
-        if self.exchange == Exchange.KUCOIN.value:
+        if self.exchange == Exchange.KUCOIN:
             return to_kucoin_granularity(self.granularity)
-        if self.exchange == Exchange.BINANCE.value:
+        if self.exchange == Exchange.BINANCE:
             return to_binance_granularity(self.granularity)
-        if self.exchange == Exchange.COINBASEPRO.value:
+        if self.exchange == Exchange.COINBASEPRO:
             return str(self.granularity)
-        if self.exchange == Exchange.DUMMY.value:
+        if self.exchange == Exchange.DUMMY:
             return str(self.granularity)
-        raise TypeError(f'Unknown exchange "{self.exchange}"')
+        raise TypeError(f'Unknown exchange "{self.exchange.value}"')
 
     def getBuyPercent(self):
         try:
@@ -241,7 +241,7 @@ class PyCryptoBot(BotConfig):
     def getHistoricalData(
         self, market, granularity: int, websocket, iso8601start="", iso8601end=""
     ):
-        if self.exchange == Exchange.BINANCE.value:
+        if self.exchange == Exchange.BINANCE:
             api = BPublicAPI(api_url=self.getAPIURL())
 
             if iso8601start != "" and iso8601end != "":
@@ -256,7 +256,7 @@ class PyCryptoBot(BotConfig):
                 return api.getHistoricalData(
                     market, to_binance_granularity(granularity), websocket
                 )
-        elif self.exchange == Exchange.KUCOIN.value:  # returns data from coinbase if not specified
+        elif self.exchange == Exchange.KUCOIN:  # returns data from coinbase if not specified
             api = KPublicAPI(api_url=self.getAPIURL())
 
             if iso8601start != "" and iso8601end == "":
@@ -405,7 +405,7 @@ class PyCryptoBot(BotConfig):
                     text_box = TextBox(80, 26)
                     text_box.singleLine()
                     text_box.center(
-                        f"{str(self.exchange)} is not returning data for the requested start date."
+                        f"{str(self.exchange.value)} is not returning data for the requested start date."
                     )
                     text_box.center(
                         f"Switching to earliest start date: {str(result_df_cache.head(1).index.format()[0])}"
@@ -451,7 +451,7 @@ class PyCryptoBot(BotConfig):
                         text_box = TextBox(80, 26)
                         text_box.singleLine()
                         text_box.center(
-                            f"{str(self.exchange)}is not returning data for the requested start date."
+                            f"{str(self.exchange.value)}is not returning data for the requested start date."
                         )
                         text_box.center(
                             f"Switching to earliest start date: {str(self.ema1226_15m_cache.head(1).index.format()[0])}"
@@ -470,7 +470,7 @@ class PyCryptoBot(BotConfig):
                         text_box = TextBox(80, 26)
                         text_box.singleLine()
                         text_box.center(
-                            f"{str(self.exchange)} is not returning data for the requested start date."
+                            f"{str(self.exchange.value)} is not returning data for the requested start date."
                         )
                         text_box.center(
                             f"Switching to earliest start date: {str(self.ema1226_1h_cache.head(1).index.format()[0])}"
@@ -523,15 +523,15 @@ class PyCryptoBot(BotConfig):
                 df_data = self.ema1226_1h_cache.loc[
                     self.ema1226_1h_cache["date"] <= iso8601end
                 ].copy()
-            elif self.exchange == Exchange.COINBASEPRO.value:
+            elif self.exchange == Exchange.COINBASEPRO:
                 api = CBPublicAPI()
                 df_data = api.getHistoricalData(self.market, 3600, websocket)
                 self.ema1226_1h_cache = df_data
-            elif self.exchange == Exchange.BINANCE.value:
+            elif self.exchange == Exchange.BINANCE:
                 api = BPublicAPI(api_url=self.getAPIURL())
                 df_data = api.getHistoricalData(self.market, "1h", websocket)
                 self.ema1226_1h_cache = df_data
-            elif self.exchange == Exchange.KUCOIN.value:
+            elif self.exchange == Exchange.KUCOIN:
                 api = KPublicAPI(api_url=self.getAPIURL())
                 df_data = api.getHistoricalData(self.market, "1hour")
                 self.ema1226_1h_cache = df_data
@@ -559,15 +559,15 @@ class PyCryptoBot(BotConfig):
                 df_data = self.sma50200_1h_cache.loc[
                     self.sma50200_1h_cache["date"] <= iso8601end
                 ].copy()
-            elif self.exchange == Exchange.COINBASEPRO.value:
+            elif self.exchange == Exchange.COINBASEPRO:
                 api = CBPublicAPI()
                 df_data = api.getHistoricalData(self.market, 3600, websocket)
                 self.sma50200_1h_cache = df_data
-            elif self.exchange == Exchange.BINANCE.value:
+            elif self.exchange == Exchange.BINANCE:
                 api = BPublicAPI(api_url=self.getAPIURL())
                 df_data = api.getHistoricalData(self.market, "1h", websocket)
                 self.sma50200_1h_cache = df_data
-            elif self.exchange == Exchange.KUCOIN.value:
+            elif self.exchange == Exchange.KUCOIN:
                 api = KPublicAPI(api_url=self.getAPIURL())
                 df_data = api.getHistoricalData(self.market, "1hour")
                 self.sma50200_1h_cache = df_data
@@ -591,13 +591,13 @@ class PyCryptoBot(BotConfig):
 
     def isCryptoRecession(self, websocket=None):
         try:
-            if self.exchange == Exchange.COINBASEPRO.value:
+            if self.exchange == Exchange.COINBASEPRO:
                 api = CBPublicAPI()
                 df_data = api.getHistoricalData(self.market, 86400, websocket)
-            elif self.exchange == Exchange.BINANCE.value:
+            elif self.exchange == Exchange.BINANCE:
                 api = BPublicAPI(api_url=self.getAPIURL())
                 df_data = api.getHistoricalData(self.market, "1d", websocket)
-            elif self.exchange == Exchange.KUCOIN.value:
+            elif self.exchange == Exchange.KUCOIN:
                 api = KPublicAPI(api_url=self.getAPIURL())
                 df_data = api.getHistoricalData(self.market, "1day")
             else:
@@ -622,15 +622,15 @@ class PyCryptoBot(BotConfig):
                 df_data = self.ema1226_6h_cache[
                     (self.ema1226_6h_cache["date"] <= iso8601end)
                 ].copy()
-            elif self.exchange == Exchange.COINBASEPRO.value:
+            elif self.exchange == Exchange.COINBASEPRO:
                 api = CBPublicAPI()
                 df_data = api.getHistoricalData(self.market, 21600, websocket)
                 self.ema1226_6h_cache = df_data
-            elif self.exchange == Exchange.BINANCE.value:
+            elif self.exchange == Exchange.BINANCE:
                 api = BPublicAPI(api_url=self.getAPIURL())
                 df_data = api.getHistoricalData(self.market, "6h", websocket)
                 self.ema1226_6h_cache = df_data
-            elif self.exchange == Exchange.KUCOIN.value:
+            elif self.exchange == Exchange.KUCOIN:
                 api = KPublicAPI(api_url=self.getAPIURL())
                 df_data = api.getHistoricalData(self.market, "6hour")
                 self.ema1226_6h_cache = df_data
@@ -654,13 +654,13 @@ class PyCryptoBot(BotConfig):
 
     def is6hSMA50200Bull(self, websocket):
         try:
-            if self.exchange == Exchange.COINBASEPRO.value:
+            if self.exchange == Exchange.COINBASEPRO:
                 api = CBPublicAPI()
                 df_data = api.getHistoricalData(self.market, 21600, websocket)
-            elif self.exchange == Exchange.BINANCE.value:
+            elif self.exchange == Exchange.BINANCE:
                 api = BPublicAPI(api_url=self.getAPIURL())
                 df_data = api.getHistoricalData(self.market, "6h", websocket)
-            elif self.exchange == Exchange.KUCOIN.value:
+            elif self.exchange == Exchange.KUCOIN:
                 api = KPublicAPI(api_url=self.getAPIURL())
                 df_data = api.getHistoricalData(self.market, "6hour")
             else:
@@ -676,11 +676,11 @@ class PyCryptoBot(BotConfig):
             return False
 
     def getTicker(self, market, websocket):
-        if self.exchange == Exchange.BINANCE.value:
+        if self.exchange == Exchange.BINANCE:
             api = BPublicAPI(api_url=self.getAPIURL())
             return api.getTicker(market, websocket)
 
-        elif self.exchange == Exchange.KUCOIN.value:
+        elif self.exchange == Exchange.KUCOIN:
             api = KPublicAPI(api_url=self.getAPIURL())
             return api.getTicker(market)
         else:  # returns data from coinbase if not specified
@@ -688,11 +688,11 @@ class PyCryptoBot(BotConfig):
             return api.getTicker(market, websocket)
 
     def getTime(self):
-        if self.exchange == Exchange.COINBASEPRO.value:
+        if self.exchange == Exchange.COINBASEPRO:
             return CBPublicAPI().getTime()
-        elif self.exchange == Exchange.KUCOIN.value:
+        elif self.exchange == Exchange.KUCOIN:
             return KPublicAPI(api_url=self.getAPIURL()).getTime()
-        elif self.exchange == Exchange.BINANCE.value:
+        elif self.exchange == Exchange.BINANCE:
             try:
                 return BPublicAPI().getTime()
             except ReadTimeoutError:
@@ -833,7 +833,7 @@ class PyCryptoBot(BotConfig):
         """Retrieves the last exchange buy order and returns a dictionary"""
 
         try:
-            if self.exchange == Exchange.COINBASEPRO.value:
+            if self.exchange == Exchange.COINBASEPRO:
                 api = CBAuthAPI(
                     self.getAPIKey(),
                     self.getAPISecret(),
@@ -864,7 +864,7 @@ class PyCryptoBot(BotConfig):
                         )[0]
                     ),
                 }
-            elif self.exchange == Exchange.KUCOIN.value:
+            elif self.exchange == Exchange.KUCOIN:
                 api = KAuthAPI(
                     self.getAPIKey(),
                     self.getAPISecret(),
@@ -895,7 +895,7 @@ class PyCryptoBot(BotConfig):
                         )[0]
                     ),
                 }
-            elif self.exchange == Exchange.BINANCE.value:
+            elif self.exchange == Exchange.BINANCE:
                 api = BAuthAPI(
                     self.getAPIKey(),
                     self.getAPISecret(),
@@ -932,15 +932,15 @@ class PyCryptoBot(BotConfig):
             return None
 
     def getTakerFee(self):
-        if self.isSimulation() is True and self.exchange == Exchange.COINBASEPRO.value:
+        if self.isSimulation() is True and self.exchange == Exchange.COINBASEPRO:
             return 0.005  # default lowest fee tier
-        elif self.isSimulation() is True and self.exchange == Exchange.BINANCE.value:
+        elif self.isSimulation() is True and self.exchange == Exchange.BINANCE:
             return 0.001  # default lowest fee tier
-        elif self.isSimulation() is True and self.exchange == Exchange.KUCOIN.value:
+        elif self.isSimulation() is True and self.exchange == Exchange.KUCOIN:
             return 0.0015  # default lowest fee tier
         elif self.takerfee > 0.0:
             return self.takerfee
-        elif self.exchange == Exchange.COINBASEPRO.value:
+        elif self.exchange == Exchange.COINBASEPRO:
             api = CBAuthAPI(
                 self.getAPIKey(),
                 self.getAPISecret(),
@@ -949,7 +949,7 @@ class PyCryptoBot(BotConfig):
             )
             self.takerfee = api.getTakerFee()
             return self.takerfee
-        elif self.exchange == Exchange.BINANCE.value:
+        elif self.exchange == Exchange.BINANCE:
             api = BAuthAPI(
                 self.getAPIKey(),
                 self.getAPISecret(),
@@ -958,7 +958,7 @@ class PyCryptoBot(BotConfig):
             )
             self.takerfee = api.getTakerFee()
             return self.takerfee
-        elif self.exchange == Exchange.KUCOIN.value:
+        elif self.exchange == Exchange.KUCOIN:
             api = KAuthAPI(
                 self.getAPIKey(),
                 self.getAPISecret(),
@@ -971,7 +971,7 @@ class PyCryptoBot(BotConfig):
             return 0.005
 
     def getMakerFee(self):
-        if self.exchange == Exchange.COINBASEPRO.value:
+        if self.exchange == Exchange.COINBASEPRO:
             api = CBAuthAPI(
                 self.getAPIKey(),
                 self.getAPISecret(),
@@ -979,7 +979,7 @@ class PyCryptoBot(BotConfig):
                 self.getAPIURL(),
             )
             return api.getMakerFee()
-        elif self.exchange == Exchange.BINANCE.value:
+        elif self.exchange == Exchange.BINANCE:
             api = BAuthAPI(
                 self.getAPIKey(),
                 self.getAPISecret(),
@@ -987,7 +987,7 @@ class PyCryptoBot(BotConfig):
                 recv_window=self.recv_window,
             )
             return api.getMakerFee()
-        elif self.exchange == Exchange.KUCOIN.value:
+        elif self.exchange == Exchange.KUCOIN:
             api = KAuthAPI(
                 self.getAPIKey(),
                 self.getAPISecret(),
@@ -1004,7 +1004,7 @@ class PyCryptoBot(BotConfig):
                 if buy_percent > 0 and buy_percent < 100:
                     quote_currency = (buy_percent / 100) * quote_currency
 
-            if self.exchange == Exchange.COINBASEPRO.value:
+            if self.exchange == Exchange.COINBASEPRO:
                 api = CBAuthAPI(
                     self.getAPIKey(),
                     self.getAPISecret(),
@@ -1012,7 +1012,7 @@ class PyCryptoBot(BotConfig):
                     self.getAPIURL(),
                 )
                 return api.marketBuy(market, float(truncate(quote_currency, 2)))
-            elif self.exchange == Exchange.KUCOIN.value:
+            elif self.exchange == Exchange.KUCOIN:
                 api = KAuthAPI(
                     self.getAPIKey(),
                     self.getAPISecret(),
@@ -1020,7 +1020,7 @@ class PyCryptoBot(BotConfig):
                     self.getAPIURL(),
                 )
                 return api.marketBuy(market, float(truncate(quote_currency, 2)))
-            elif self.exchange == Exchange.BINANCE.value:
+            elif self.exchange == Exchange.BINANCE:
                 api = BAuthAPI(
                     self.getAPIKey(),
                     self.getAPISecret(),
@@ -1036,7 +1036,7 @@ class PyCryptoBot(BotConfig):
             if isinstance(sell_percent, int):
                 if sell_percent > 0 and sell_percent < 100:
                     base_currency = (sell_percent / 100) * base_currency
-                if self.exchange == Exchange.COINBASEPRO.value:
+                if self.exchange == Exchange.COINBASEPRO:
                     api = CBAuthAPI(
                         self.getAPIKey(),
                         self.getAPISecret(),
@@ -1044,7 +1044,7 @@ class PyCryptoBot(BotConfig):
                         self.getAPIURL(),
                     )
                     return api.marketSell(market, base_currency)
-                elif self.exchange == Exchange.BINANCE.value:
+                elif self.exchange == Exchange.BINANCE:
                     api = BAuthAPI(
                         self.getAPIKey(),
                         self.getAPISecret(),
@@ -1052,7 +1052,7 @@ class PyCryptoBot(BotConfig):
                         recv_window=self.recv_window,
                     )
                     return api.marketSell(market, base_currency)
-                elif self.exchange == Exchange.KUCOIN.value:
+                elif self.exchange == Exchange.KUCOIN:
                     api = KAuthAPI(
                         self.getAPIKey(),
                         self.getAPISecret(),
@@ -1064,19 +1064,19 @@ class PyCryptoBot(BotConfig):
                 return None
 
     def setMarket(self, market):
-        if self.exchange == Exchange.BINANCE.value:
+        if self.exchange == Exchange.BINANCE:
             self.market, self.base_currency, self.quote_currency = binanceParseMarket(
                 market
             )
 
-        elif self.exchange == Exchange.COINBASEPRO.value:
+        elif self.exchange == Exchange.COINBASEPRO:
             (
                 self.market,
                 self.base_currency,
                 self.quote_currency,
             ) = coinbaseProParseMarket(market)
 
-        elif self.exchange == Exchange.KUCOIN.value:
+        elif self.exchange == Exchange.KUCOIN:
             (self.market, self.base_currency, self.quote_currency) = kucoinParseMarket(
                 market
             )
@@ -1137,7 +1137,7 @@ class PyCryptoBot(BotConfig):
                     endDate = self.getDateFromISO8601Str(
                         str(pd.Series(datetime.now()).dt.round(freq="H")[0])
                     )
-                    if self.getExchange() == Exchange.COINBASEPRO.value:
+                    if self.getExchange() == Exchange.COINBASEPRO:
                         endDate -= timedelta(
                             hours=random.randint(0, 8760 * 3)
                         )  # 3 years in hours
@@ -1257,7 +1257,7 @@ class PyCryptoBot(BotConfig):
             text_box.line("Bot Mode", "TEST - test trades using dummy funds :)")
 
         text_box.line("Bot Started", str(datetime.now()))
-        text_box.line("Exchange", str(self.exchange))
+        text_box.line("Exchange", str(self.exchange.value))
         text_box.doubleLine()
 
         if self.sellUpperPcnt() != None:

--- a/models/Stats.py
+++ b/models/Stats.py
@@ -2,6 +2,7 @@ import sys
 from datetime import datetime, timedelta
 from models.PyCryptoBot import PyCryptoBot
 from models.TradingAccount import TradingAccount
+from models.exchange.ExchangesEnum import Exchange
 from models.helper.LogHelper import Logger
 
 class Stats():
@@ -28,7 +29,7 @@ class Stats():
         for index, row in self.orders.iterrows():
             time = row['created_at'].to_pydatetime()
             if row['action'] == 'buy':
-                if self.app.exchange == 'coinbasepro':
+                if self.app.exchange == Exchange.COINBASEPRO:
                     amount = row['filled'] * row['price'] + row['fees']
                 else:
                     amount = row['size']
@@ -38,7 +39,7 @@ class Stats():
                 else:
                     self.order_pairs[-1]['buy']['size'] += amount
             else:
-                if self.app.exchange == 'coinbasepro':
+                if self.app.exchange == Exchange.COINBASEPRO:
                     amount = (row['filled'] * row['price']) - row['fees']
                 else:
                     amount = (float(row['filled']) * float(row['price'])) - row['fees']

--- a/models/TradingAccount.py
+++ b/models/TradingAccount.py
@@ -59,15 +59,15 @@ class TradingAccount:
         market : str
             market to check
         """
-        if self.app.getExchange() == Exchange.COINBASEPRO.value and market != "":
+        if self.app.getExchange() == Exchange.COINBASEPRO and market != "":
             p = re.compile(r"^[1-9A-Z]{2,5}\-[1-9A-Z]{2,5}$")
             if not p.match(market):
                 raise TypeError("Coinbase Pro market is invalid.")
-        elif self.app.getExchange() == Exchange.BINANCE.value:
+        elif self.app.getExchange() == Exchange.BINANCE:
             p = re.compile(r"^[A-Z]{5,12}$")
             if not p.match(market):
                 raise TypeError("Binance market is invalid.")
-        elif self.app.getExchange() == Exchange.KUCOIN.value:
+        elif self.app.getExchange() == Exchange.KUCOIN:
             p = re.compile(r"^[1-9A-Z]{2,5}\-[1-9A-Z]{2,5}$")
             if not p.match(market):
                 raise TypeError("Kucoin market is invalid.")
@@ -97,7 +97,7 @@ class TradingAccount:
         if not status in ["open", "pending", "done", "active", "all", "filled"]:
             raise ValueError("Invalid order status.")
 
-        if self.app.getExchange() == Exchange.BINANCE.value:
+        if self.app.getExchange() == Exchange.BINANCE:
             if self.mode == "live":
                 # if config is provided and live connect to Binance account portfolio
                 model = BAuthAPI(
@@ -116,7 +116,7 @@ class TradingAccount:
                 else:
                     return self.orders[self.orders["market"] == market]
 
-        if self.app.getExchange() == Exchange.KUCOIN.value:
+        if self.app.getExchange() == Exchange.KUCOIN:
             if self.mode == 'live':
                 # if config is provided and live connect to Kucoin account portfolio
                 model = KAuthAPI(
@@ -134,7 +134,7 @@ class TradingAccount:
                 else:
                     return self.orders[self.orders['market'] == market]
 
-        if self.app.getExchange() == Exchange.COINBASEPRO.value:
+        if self.app.getExchange() == Exchange.COINBASEPRO:
             if self.mode == "live":
                 # if config is provided and live connect to Coinbase Pro account portfolio
                 model = CBAuthAPI(
@@ -155,7 +155,7 @@ class TradingAccount:
                         return self.orders[self.orders["market"] == market]
                     else:
                         return pd.DataFrame()
-        if self.app.getExchange() == Exchange.DUMMY.value:
+        if self.app.getExchange() == Exchange.DUMMY:
             return self.orders[
                 [
                     "created_at",
@@ -179,7 +179,7 @@ class TradingAccount:
             Filters orders by currency
         """
 
-        if self.app.getExchange() == Exchange.KUCOIN.value:
+        if self.app.getExchange() == Exchange.KUCOIN:
             if self.mode == 'live':
                 model = KAuthAPI(self.app.getAPIKey(), self.app.getAPISecret(), self.app.getAPIPassphrase(), self.app.getAPIURL())
                 df = model.getAccounts()
@@ -207,7 +207,7 @@ class TradingAccount:
                     # retrieve all balances
                     return self.balance
                 else:
-                    if self.app.getExchange() == Exchange.KUCOIN.value:
+                    if self.app.getExchange() == Exchange.KUCOIN:
                         self.balance = self.balance.replace('QUOTE', currency)
                     else:
                         # replace QUOTE and BASE placeholders
@@ -233,7 +233,7 @@ class TradingAccount:
                         else:
                             return float(truncate(float(df[df['currency'] == currency]['available'].values[0]), 4))
 
-        elif self.app.getExchange() == Exchange.BINANCE.value:
+        elif self.app.getExchange() == Exchange.BINANCE:
             if self.mode == "live":
                 model = BAuthAPI(
                     self.app.getAPIKey(),
@@ -288,7 +288,7 @@ class TradingAccount:
                     # retrieve all balances
                     return self.balance
                 else:
-                    if self.app.getExchange() == Exchange.BINANCE.value:
+                    if self.app.getExchange() == Exchange.BINANCE:
                         self.balance = self.balance.replace("QUOTE", currency)
                     else:
                         # replace QUOTE and BASE placeholders
@@ -334,7 +334,7 @@ class TradingAccount:
                                 )
                             )
 
-        elif self.app.getExchange() == Exchange.COINBASEPRO.value:
+        elif self.app.getExchange() == Exchange.COINBASEPRO:
             if self.mode == "live":
                 # if config is provided and live connect to Coinbase Pro account portfolio
                 model = CBAuthAPI(
@@ -738,13 +738,13 @@ class TradingAccount:
         self._checkMarketSyntax(market)
 
         if self.mode == "live":
-            if self.app.getExchange() == Exchange.COINBASEPRO.value:
+            if self.app.getExchange() == Exchange.COINBASEPRO:
                 # retrieve orders from live Coinbase Pro account portfolio
                 df = self.getOrders(market, "", "done")
-            elif self.app.getExchange() == Exchange.BINANCE.value:
+            elif self.app.getExchange() == Exchange.BINANCE:
                 # retrieve orders from live Binance account portfolio
                 df = self.getOrders(market, "", "done")
-            elif self.app.getExchange() == Exchange.KUCOIN.value:
+            elif self.app.getExchange() == Exchange.KUCOIN:
                 # retrieve orders from live Kucoin account portfolio
                 df = self.getOrders(market, '', 'done')
             else:

--- a/pycryptobot.py
+++ b/pycryptobot.py
@@ -277,7 +277,7 @@ def executeJob(
         list(map(s.cancel, s.queue))
         s.enter(5, 1, executeJob, (sc, _app, _state, _technical_analysis, _websocket))
 
-    if _app.getExchange() == Exchange.BINANCE.value and _app.getGranularity() == 86400:
+    if _app.getExchange() == Exchange.BINANCE and _app.getGranularity() == 86400:
         if len(df) < 250:
             # data frame should have 250 rows, if not retry
             Logger.error(f"error: data frame length is < 250 ({str(len(df))})")
@@ -433,8 +433,8 @@ def executeJob(
                         _state.last_buy_price = exchange_last_buy["price"]
 
                     if (
-                        _app.getExchange() == Exchange.COINBASEPRO.value
-                        or _app.getExchange() == Exchange.COINBASEPRO.value
+                        _app.getExchange() == Exchange.COINBASEPRO
+                        or _app.getExchange() == Exchange.COINBASEPRO
                     ):
                         if _state.last_buy_fee != exchange_last_buy["fee"]:
                             _state.last_buy_fee = exchange_last_buy["fee"]
@@ -1637,9 +1637,9 @@ def executeJob(
         # if live but not websockets
         if not _app.disableTracker() and _app.isLive() and not _app.enableWebsocket():
             # update order tracker csv
-            if _app.getExchange() == Exchange.BINANCE.value:
+            if _app.getExchange() == Exchange.BINANCE:
                 account.saveTrackerCSV(_app.getMarket())
-            elif _app.getExchange() == Exchange.COINBASEPRO.value or _app.getExchange() == Exchange.COINBASEPRO.value:
+            elif _app.getExchange() == Exchange.COINBASEPRO or _app.getExchange() == Exchange.KUCOIN:
                 account.saveTrackerCSV()
 
         if _app.isSimulation():
@@ -1682,19 +1682,19 @@ def main():
     try:
         _websocket = None
         message = "Starting "
-        if app.getExchange() == Exchange.COINBASEPRO.value:
+        if app.getExchange() == Exchange.COINBASEPRO:
             message += "Coinbase Pro bot"
             if app.enableWebsocket() and not app.isSimulation():
                 print("Opening websocket to Coinbase Pro...")
                 _websocket = CWebSocketClient([app.getMarket()], app.getGranularity())
                 _websocket.start()
-        elif app.getExchange() == Exchange.BINANCE.value:
+        elif app.getExchange() == Exchange.BINANCE:
             message += "Binance bot"
             if app.enableWebsocket() and not app.isSimulation():
                 print("Opening websocket to Binance...")
                 _websocket = BWebSocketClient([app.getMarket()], app.getGranularity())
                 _websocket.start()
-        elif app.getExchange() == Exchange.COINBASEPRO.value:
+        elif app.getExchange() == Exchange.KUCOIN:
             message += "Kucoin bot"
 
         smartSwitchStatus = "enabled" if app.getSmartSwitch() else "disabled"

--- a/tests/unit_tests/test_exchange_binance.py
+++ b/tests/unit_tests/test_exchange_binance.py
@@ -5,12 +5,14 @@ import requests
 import sys
 import pandas
 
+from models.exchange.ExchangesEnum import Exchange
+
 sys.path.append(".")
 # pylint: disable=import-error
 from models.PyCryptoBot import PyCryptoBot
 from models.exchange.binance import AuthAPI, PublicAPI
 
-app = PyCryptoBot(exchange="binance")
+app = PyCryptoBot(exchange=Exchange.BINANCE)
 
 
 @responses.activate

--- a/tests/unit_tests/test_exchange_coinbase.py
+++ b/tests/unit_tests/test_exchange_coinbase.py
@@ -5,12 +5,14 @@ import requests
 import sys
 import pandas
 
+from models.exchange.ExchangesEnum import Exchange
+
 sys.path.append('.')
 # pylint: disable=import-error
 from models.PyCryptoBot import PyCryptoBot
 from models.exchange.coinbase_pro import AuthAPI, PublicAPI
 
-app = PyCryptoBot(exchange='coinbasepro')
+app = PyCryptoBot(exchange= Exchange.COINBASEPRO)
 
 def test_instantiate_authapi_without_error():
     global app


### PR DESCRIPTION
## Description

In my previous PRhttps://github.com/whittlem/pycryptobot/pull/547, I introduced an exchange enum to avoid using strings when comparing exchanges, however, I kept the same behaviour, but I was comparing with the Enum value. 

This change completes the migration and starts comparing the enums, instead of Strings.

Fixes # (issue)

## Type of change

Please make your selection.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This change requires a new dependency
- [x] Code Maintainability / comments
- [x] Code Refactoring / future-proofing

## How Has This Been Tested?

Running bot in Live Mode, Non-live Mode and Sim Mode with `--exchange` being specified in the command line and getting the exchange from the `config.json`

## Checklist:

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added pytest unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
