### PR TITLE
Adding granularity config to default_parser.py

### DIFF
--- a/models/config/binance_parser.py
+++ b/models/config/binance_parser.py
@@ -4,7 +4,6 @@ import os.path
 import re
 
 from .default_parser import isCurrencyValid, defaultConfigParse, merge_config_and_args
-from ..exchange.Granularity import Granularity
 
 
 def isMarketValid(market) -> bool:
@@ -143,7 +142,3 @@ def parser(app, binance_config, args={}):
 
     if app.base_currency != '' and app.quote_currency != '':
         app.market = app.base_currency + app.quote_currency
-
-    if 'granularity' in config and config['granularity'] is not None:
-        app.granularity = Granularity.convert_to_enum(config['granularity'])
-        app.smart_switch = 0

--- a/models/config/coinbase_pro_parser.py
+++ b/models/config/coinbase_pro_parser.py
@@ -1,9 +1,10 @@
-import re
 import ast
 import json
 import os.path
+import re
 
 from .default_parser import isCurrencyValid, defaultConfigParse, merge_config_and_args
+
 
 def isMarketValid(market) -> bool:
     p = re.compile(r"^[1-9A-Z]{2,5}\-[1-9A-Z]{2,5}$")
@@ -124,16 +125,3 @@ def parser(app, coinbase_config, args={}):
 
     if app.base_currency != '' and app.quote_currency != '':
         app.market = app.base_currency + '-' + app.quote_currency
-
-    if 'granularity' in config and config['granularity'] is not None:
-        granularity = 0
-        if isinstance(config['granularity'], str) and config['granularity'].isnumeric() is True:
-            granularity = int(config['granularity'])
-        elif isinstance(config['granularity'], int):
-            granularity = config['granularity']
-
-        if granularity in [60, 300, 900, 3600, 21600, 86400]:
-            app.granularity = granularity
-            app.smart_switch = 0
-        else:
-            raise ValueError('granularity supplied is not supported.')

--- a/models/config/default_parser.py
+++ b/models/config/default_parser.py
@@ -1,5 +1,6 @@
 import re
-import sys
+
+from models.exchange.Granularity import Granularity
 
 
 def merge_config_and_args(exchange_config, args):
@@ -468,3 +469,10 @@ def defaultConfigParse(app, config):
                 app.logbuysellinjson = True
         else:
             raise TypeError("logbuysellinjson must be of type int")
+
+    if 'granularity' in config and config['granularity'] is not None:
+        app.smart_switch = 0
+        if isinstance(config['granularity'], str) and not config['granularity'].isnumeric() is True:
+            app.granularity = Granularity.convert_to_enum(config['granularity'])
+        else:
+            app.granularity = Granularity.convert_to_enum(int(config['granularity']))

--- a/models/config/kucoin_parser.py
+++ b/models/config/kucoin_parser.py
@@ -10,9 +10,6 @@ def isMarketValid(market) -> bool:
     p = re.compile(r"^[1-9A-Z]{2,5}\-[1-9A-Z]{2,5}$")
     return p.match(market) is not None
 
-def to_internal_granularity(granularity: str) -> int:
-    return {'1min': 60, '5min': 300, '15min': 900, '1hour': 3600, '6hour': 21600, '1day': 86400}[granularity]
-
 def parseMarket(market):
     if not isMarketValid(market):
         raise ValueError('Kucoin market invalid: ' + market)
@@ -130,14 +127,3 @@ def parser(app, Kucoin_config, args={}):
 
     if app.base_currency != '' and app.quote_currency != '':
         app.market = app.base_currency + '-' + app.quote_currency
-
-    if 'granularity' in config and config['granularity'] is not None:
-        if isinstance(config['granularity'], str):
-            if config['granularity'] in ['1min', '5min', '15min', '1hour', '6hour', '1day']:
-                app.granularity = to_internal_granularity(config['granularity'])
-                app.smart_switch = 0
-            else:
-                app.granularity = int(config['granularity'])
-                app.smart_switch = 0
-            # else:
-            #     raise ValueError('granularity supplied is not supported.')


### PR DESCRIPTION
Signed-off-by: edrick <edrickrenan@gmail.com>

## Description

With the introduction of the Granularity Enum, we don't need to parse the granularity for each exchange individually, instead, we can have it in a shared location e.g. default_parser.py

Fixes # (issue)

## Type of change

Please make your selection.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This change requires a new dependency
- [x] Code Maintainability / comments
- [x] Code Refactoring / future-proofing

## How Has This Been Tested?

1 - running the code for binance with granularity set is working
2 - running the code for binance with no granularity is working
3 - running the code for coinbasepro with no granularity is working
3 - running the code for coinbasepro with integer granularity (900) is working
3 - running the code for coinbasepro with string granularity ("900") is working

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added pytest unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
