### PR TITLE
fix for TGBot helper error when not using TG bot

### DIFF
--- a/models/helper/TelegramBotHelper.py
+++ b/models/helper/TelegramBotHelper.py
@@ -245,20 +245,20 @@ class TelegramBotHelper:
         if not self.app.isSimulation() and self.app.enableTelegramBotControl():
             self._read_data("data.json")
 
-        if self.market in self.data["opentrades"]:
-            if self.exchange != self.data["opentrades"][self.market]:
-                return
+            if self.market in self.data["opentrades"]:
+                if self.exchange != self.data["opentrades"][self.market]:
+                    return
 
-        self.data["opentrades"].update({self.market : {"exchange": self.exchange.value}})
-        self._write_data("data.json")
+            self.data["opentrades"].update({self.market : {"exchange": self.exchange.value}})
+            self._write_data("data.json")
 
     def remove_open_order(self):
         if not self.app.isSimulation() and self.app.enableTelegramBotControl():
             self._read_data("data.json")
 
-        if self.market not in self.data["opentrades"]:
-            return
+            if self.market not in self.data["opentrades"]:
+                return
 
-        self.data["opentrades"].pop(self.market)
-        self._write_data("data.json")
+            self.data["opentrades"].pop(self.market)
+            self._write_data("data.json")
 

--- a/telegram_bot.py
+++ b/telegram_bot.py
@@ -632,7 +632,7 @@ class TelegramBot(TelegramBotBase):
             )
             if "margin" not in self.helper.data:
                 logger.info("deleting %s", jfile)
-                os.remove(os.path.join(self.datafolder, "telegram_data", jfile))
+                os.remove(os.path.join(self.datafolder, "telegram_data", f"{jfile}.json"))
                 continue
             if (
                 self.helper.data["botcontrol"]["status"] == "active"
@@ -650,7 +650,7 @@ class TelegramBot(TelegramBotBase):
                 and last_modified.seconds != 86399
             ):
                 logger.info("deleting %s %s", jfile, str(last_modified.seconds))
-                os.remove(os.path.join(self.datafolder, "telegram_data", jfile))
+                os.remove(os.path.join(self.datafolder, "telegram_data", f"{jfile}.json"))
 
     def ExceptionExchange(self, update, context):
         """start new bot ask which exchange"""


### PR DESCRIPTION
Fix for:

AttributeError("'TelegramBotHelper' object has no attribute 'data'")

when not using TelegramBot Control

Please make your selection.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This change requires a new dependency
- [ ] Code Maintainability / comments
- [ ] Code Refactoring / future-proofing

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

## Checklist:

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added pytest unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
