### PR TITLE
Given the formula  (c) in this documentation in the description it seems that the cumulative returns is missing…

### DIFF
--- a/models/Trading.py
+++ b/models/Trading.py
@@ -681,7 +681,7 @@ class TechnicalAnalysis:
         self.df["close_pc"] = self.changePct()
 
         # cumulative returns
-        self.df["close_cpc"] = (1 + self.df["close_pc"]).cumprod()
+        self.df["close_cpc"] = (1 + self.df["close_pc"]).cumprod() - 1
 
     def cumulativeMovingAverage(self) -> float:
         """Calculates the Cumulative Moving Average (CMA)"""


### PR DESCRIPTION
When i read a documentation of a cumulative return i see that there is a missing substraction  of 1 at the end of the line. 

https://www.allthesnippets.com/notes/finance/calculating_cumulative_returns_of_stocks_with_python_and_pandas.html#What-Is-a-Return?

## Description

Just added the missing (-1)

Fixes # (issue)

## Type of change

Please make your selection.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This change requires a new dependency
- [ ] Code Maintainability / comments
- [ ] Code Refactoring / future-proofing

## How Has This Been Tested?

Just run the bot. Check the correct values in Trading.py 

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added pytest unit tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings
