### PR TITLE
Fix scan kucoin leverage

### DIFF
--- a/models/telegram/actions.py
+++ b/models/telegram/actions.py
@@ -280,7 +280,7 @@ class TelegramActions():
                         break
                     
                     if self.helper.config["scanner"]["enableleverage"] == False \
-                            and (str(row).__contains__(f"DOWN{quote}") or str(row).__contains__(f"UP{quote}") or str(row).__contains__(f"3L{quote}") or str(row).__contains__(f"3S{quote}")):
+                            and (str(row).__contains__(f"DOWN{quote}") or str(row).__contains__(f"UP{quote}") or str(row).__contains__(f"3L-{quote}") or str(row).__contains__(f"3S-{quote}")):
                         continue
 
                     if row in self.helper.data["scannerexceptions"]:

--- a/telegram_bot.py
+++ b/telegram_bot.py
@@ -245,7 +245,7 @@ class TelegramBot(TelegramBotBase):
             return ConversationHandler.END
 
         if self.exchange in ("coinbasepro", "kucoin"):
-            p = re.compile(r"^[1-9A-Z]{2,9}\-[1-9A-Z]{2,5}$")
+            p = re.compile(r"^[1-9A-Z]{2,20}\-[1-9A-Z]{2,5}$")
             if not p.match(update.message.text):
                 update.message.reply_text(
                     "Invalid market format", reply_markup=ReplyKeyboardRemove()


### PR DESCRIPTION
## Description

1.  Fixes issue where KUCOIN leveraged tokens are not excluded when scanner section in config.json has "enableleverage": 0 set.
2.  Fixes issue where telegram bot will not add a new KUCOIN pair where the base currency has more than 9 characters (eg. Trying to add FORESTPLUS-USDT results in 'invalid market' error).

Fixes # (issue)

## Type of change

Please make your selection.

- [X ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This change requires a new dependency
- [ ] Code Maintainability / comments
- [ ] Code Refactoring / future-proofing

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.
These are 2 minor changes been running on my setup with no issues.

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ x] My changes generate no new warnings
- [ ] I have added pytest unit tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings
