### PR TITLE
Add preventloss and trailingimmediatebuy options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ Upgrade version:
 Upgrade library dependencies (if required):
 - python3 -m pip install -r requirements.txt -U
 
+## [5.1.0] - 2021-12-27
+
+- added trailingimmediatebuy option to buy as soon as trailingbuypcnt is reached, instead of waiting until candle close
+- added preventloss option to enable selling prior to margin reaching 0% profit to prevent loss
+- added preventlosstrigger - margin set point to start watching for preventloss (see readme)
+- added preventlossmargin - margin set point to sell at for preventloss (see readme)
+- reordered some test in isSellTrigger to minimize processing on every pass under some conditions
+
 ## [5.0.2] - 2021-12-26
 
 - revised fix for change_pcnt_high variable from previous

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![Docker](https://github.com/whittlem/pycryptobot/actions/workflows/container.yml/badge.svg)](https://github.com/whittlem/pycryptobot/actions/workflows/container.yml/badge.svg) [![Tests](https://github.com/whittlem/pycryptobot/actions/workflows/unit-tests.yml/badge.svg)](https://github.com/whittlem/pycryptobot/actions/workflows/unit-tests.yml/badge.svg)
 
 
-# Python Crypto Bot v5.0.1 (pycryptobot)
+# Python Crypto Bot v5.1.0 (pycryptobot)
 
 ## Join our chat on Telegram
 
@@ -379,9 +379,7 @@ Special buy cases:
 * "buymaxsize" specifies a fixed max amount of the quote currency to buy with.
 * "buylastsellsize" when enabled, bot will buy the same size as the last sell size for the current market.
 * "trailingbuypcnt" specifies the percentage for the price to increase before placing buy order after receiving buy signal
-        The default percentage is 0%.  If the price drops after receiving buy signal, the bot will automatically follow the price
-        down and watch for it to have a positive percentage.  You are able to adjust this to any number above zero that you would 
-        like to see as an increase before buying.  Many times the price falls below zero right after a buy signal is received.
+* "trailingimmediatebuy" will trigger an immediate buy if "trailingbuypcnt" is reached.  Use caution, may not advisable on all markets. Default is to wait until candle close to process buy like a standard buy signal.
 * "marketmultibuycheck" when enabled, bot will perform an additional check on base and quote balance to prevent multiple buys.
         It has been determined that some market pairs have problem API responses which can create a multiple buy issue.
         Please Note:  "marketmultibuycheck" will conflict with configurations that use "sellpercent".
@@ -402,6 +400,10 @@ Special sell cases:
 * If the margin exceeds 3% and the price reaches a Fibonacci band it will sell to lock in profit
 * If the margin exceeds 3% but a strong reversal is detected with negative OBV and MACD < Signal it will sell
 * "sellatloss" set to 0 prevents selling at a loss
+* "preventloss" set to 1 to force a sell before margin is negative (losing money on active trade).  Default trigger point is 1%.  If nosellmaxpcnt is set it will be used as the default, unless preventlosstrigger is set to set a custom trigger point.
+* "preventlosstrigger" is the margin set point that will trigger/allow the preventloss function to start watching the margin and will sell when margin reaches 0.1% or lower unless preventlossmargin is set.
+  NOTE: to disable preventlosstrigger and use preventlossmargin only, set the trigger to 0.
+* "preventlossmargin" is the margin set point that will cause an immediate sell to prevent a loss.  If this is not set, a default of 0.1% will be used.  "preventlossmargin" can be used by itself or in conjunction with "preventlosstrigger".
 
 ## Optional Options
 
@@ -434,6 +436,22 @@ Special sell cases:
 ## "Sell At Loss" explained
 
 The "sellatloss" option disabled has it's advantages and disadvantages. It does prevent any losses but also prevents you from exiting a market before a crash or bear market. Sometimes it's better to make an occasional small loss and make it up with several buys than be conservative and potentially lock a trade for weeks if not months. It happened to me while testing this with the last crash (after Elon's tweet!). Three of my bots did not sell while the profit dropped to -10 to -20%. It did bounce back and I made over 3% a trade with any losses but I also lost out of loads of trading opportunities. It's really a matter of preference. Maybe some markets would be more appropriate than others for this.
+
+## "Prevent Loss" explained
+
+The "preventloss" option and it's corresponding settings add more options to control losses or minimize losses on trades.  "preventloss" does not depend on "sellatloss" to work.  The idea of Prevent Loss is to allow you to still use all the other sell criteria and the no sell zones as you would like, but still sell prior to the margin dropping below 0%.  Note: there are still transaction fees from the exchange, this has no effect on fees.  You could increase preventlossmargin to account for fees if you would like.
+If "preventloss" is set to 1 and enabled, it will watch for the "preventlosstrigger" margin percentage to be reached. If "preventloss" is enabled and "preventlosstrigger" is NOT in you configuration the default "preventlosstrigger" is 1%.  Once the trigger percentage is reached, preventloss will monitor the margin until it falls to the "preventlossmargin" set point.  If "preventlossmargin" is not in your configuration, it has a default setting of 0.1% to make the best attempt to trigger a sell before the margin drops below 0%.  On very fast falling prices, the margin could fall below 0% before the transaction is processed by the exchange.  Set at a level that you are comfortable with so the margin falls in the range you would like.
+
+"preventloss" and "preventlossmargin" can be used without "preventlosstrigger" if you choose.  Set "preventlosstrigger" to 0 in your config to disable it and sell any time the margin drops below the "preventlosmargin" set point.  It is assumed that most users won't want this option which is why you have to disable "preventlosstrigger" for it to function in this manner.
+
+Prevent Loss is not a required option.  It allows a little more control over your profits and losses.
+
+## Trailing Buy Percent Explained
+
+When the bot issues a standard buy signal via all normal methods, it waits until the next candle close to buy.  Many times after a buy signal is given, the price for the pair in question will still fall.  Trailing buy will, by default,  check to make sure the price is moving in a positive/upward direction before it buys.  If the price goes lower after the buy signal is given, trailing buy will watch the price changes and will prevent a buy if the price is dropping until it starts to increase again.  This will actually make the bot buy at the lowest price monitored after the buy signal was received.  The default is 0% of increase, so it will only prevent buying from the buy signal until next candle close if the price is decreasing.  At close, if the price is still falling, it will delay the buy again until next close.  This essentially takes an extra step to help stop you from possibly losing profit immediately after a buy, especially when using MACD signals only.
+"trailingbuypcnt" can be set at any percentage above 0.  Run some simualutions or use live: 0 to test the results of various percentage set points.  During testing, 1% had pretty good results, but all trade settings will vary based on market and pair being traded.  It is always recommened that you run tests before trading live with real funds.
+
+"trailingimmediatebuy" is another setting that can be used in conjunction with "trailingbuypcnt".  If "trailingimmediatebuy" is enabled (set to 1), "trailingbuypcnt" will buy immediately upon the set point being reached, instead of waiting until candle close.  Again, run tests to determine the best settings. 
 
 ## Live Trading
 

--- a/models/AppState.py
+++ b/models/AppState.py
@@ -66,7 +66,7 @@ class AppState:
         self.last_df_index = ""
         self.sell_count = 0
         self.sell_sum = 0
-
+        self.prevent_loss = 0
         self.margintracker = 0
         self.profitlosstracker = 0
         self.feetracker = 0

--- a/models/BotConfig.py
+++ b/models/BotConfig.py
@@ -51,6 +51,9 @@ class BotConfig:
         self.sell_at_loss = 1
         self.smart_switch = 1
         self.sell_smart_switch = 0
+        self.preventloss = False
+        self.preventlosstrigger = None
+        self.preventlossmargin = None
 
         self.telegram = False
 
@@ -67,6 +70,7 @@ class BotConfig:
 
         self.buylastsellsize = False
         self.trailingbuypcnt = 0
+        self.trailingimmediatebuy = False
         self.marketmultibuycheck = False
 
         self.sellatresistance = False
@@ -407,6 +411,21 @@ class BotConfig:
             help="optionally set when the trailing stop loss should start",
         )
         parser.add_argument(
+            "--preventloss",
+            action="store_true",
+            help="optionally sell before margin is negative",
+        )
+        parser.add_argument(
+            "--preventlosstrigger",
+            type=float,
+            help="optionally set when the trigger when preventloss should start",
+        )
+        parser.add_argument(
+            "--preventlossmargin",
+            type=float,
+            help="optionally set margin to sell at regardless of other settings",
+        )
+        parser.add_argument(
             "--sim", type=str, help="simulation modes: fast, fast-sample, slow-sample"
         )
         parser.add_argument(
@@ -461,6 +480,7 @@ class BotConfig:
 
         parser.add_argument("--buylastsellsize", action="store_true", help="additional check for market multiple buys")
         parser.add_argument("--trailingbuypcnt", type=float, help="percent of increase to wait before buying")
+        parser.add_argument("--trailingimmediatebuy", action="store_true", help="immediate buy if trailingbuypcnt reached")
         parser.add_argument("--marketmultibuycheck", action="store_true", help="")
 
         parser.add_argument(

--- a/models/PyCryptoBot.py
+++ b/models/PyCryptoBot.py
@@ -214,6 +214,9 @@ class PyCryptoBot(BotConfig):
         except Exception:  # pylint: disable=broad-except
             return 0
 
+    def trailingImmediateBuy(self) -> bool:
+        return self.trailingimmediatebuy
+
     def marketMultiBuyCheck(self) -> bool:
         return self.marketmultibuycheck
 
@@ -802,6 +805,15 @@ class PyCryptoBot(BotConfig):
     def trailingStopLossTrigger(self):
         return self.trailing_stop_loss_trigger
 
+    def preventLoss(self):
+        return self.preventloss
+
+    def preventLossTrigger(self):
+        return self.preventlosstrigger
+
+    def preventLossMargin(self):
+        return self.preventlossmargin
+
     def allowSellAtLoss(self) -> bool:
         return self.sell_at_loss == 1
 
@@ -1381,6 +1393,24 @@ class PyCryptoBot(BotConfig):
                 str(self.trailingStopLossTrigger()) + "%  --trailingstoplosstrigger",
             )
 
+        if self.preventLoss():
+            text_box.line(
+                "Prevent Loss",
+                str(self.preventLoss()) + "  --preventloss",
+            )
+
+        if self.preventLossTrigger() != None:
+            text_box.line(
+                "Prevent Loss Trigger",
+                str(self.preventLossTrigger()) + "%  --preventlosstrigger",
+            )
+
+        if self.preventLossMargin() != None:
+            text_box.line(
+                "Prevent Loss Margin",
+                str(self.preventLossMargin()) + "%  --preventlossmargin",
+            )
+
         text_box.line("Sell At Loss", str(self.allowSellAtLoss()) + "  --sellatloss ")
         text_box.line(
             "Sell At Resistance", str(self.sellAtResistance()) + "  --sellatresistance"
@@ -1482,6 +1512,12 @@ class PyCryptoBot(BotConfig):
         if self.getTrailingBuyPcnt():
             text_box.line(
                 "Trailing Buy Percent", str(self.getTrailingBuyPcnt()) + "  --trailingbuypcnt <size>"
+            )
+
+        if self.trailingImmediateBuy():
+            text_box.line(
+                "Immediate buy for trailingbuypcnt",
+                str(self.trailingImmediateBuy()) + "  --trailingImmediateBuy",
             )
 
         if self.marketMultiBuyCheck():

--- a/models/config/default_parser.py
+++ b/models/config/default_parser.py
@@ -280,6 +280,34 @@ def defaultConfigParse(app, config):
         else:
             raise TypeError("sellatloss must be of type int")
 
+    if "preventloss" in config:
+        if isinstance(config["preventloss"], int):
+            if bool(config["preventloss"]):
+                app.preventloss = True
+        else:
+            raise TypeError("preventloss must be of type int")
+
+    if "preventlosstrigger" in config:
+        if isinstance(config["preventlosstrigger"], (int, float)):
+            if config["preventlosstrigger"] is not None:
+                app.preventlosstrigger = config["preventlosstrigger"]
+        else:
+            raise TypeError("preventlossmargin must be of type int or float")
+    elif app.preventloss:
+        if app.nosellmaxpcnt is not None:
+            app.preventlosstrigger = app.nosellmaxpcnt
+        else:
+            app.preventlosstrigger = 1
+
+    if "preventlossmargin" in config:
+        if isinstance(config["preventlossmargin"], (int, float)):
+            if config["preventlossmargin"] is not None:
+                app.preventlossmargin = config["preventlossmargin"]
+        else:
+            raise TypeError("preventlossmargin must be of type int or float")
+    elif app.preventloss:
+        app.preventlossmargin = 0.1
+
     if "simresultonly" in config:
         if isinstance(config["simresultonly"], int):
             if bool(config["simresultonly"]):
@@ -515,6 +543,13 @@ def defaultConfigParse(app, config):
                 app.trailingbuypcnt = config["trailingbuypcnt"]
         else:
             raise TypeError("trailingbuypcnt must be of type int or float")
+
+    if "trailingimmediatebuy" in config:
+        if isinstance(config["trailingimmediatebuy"], int):
+            if bool(config["trailingimmediatebuy"]):
+                app.trailingimmediatebuy = True
+        else:
+            raise TypeError("trailingimmediatebuy must be of type int")
 
     if "marketmultibuycheck" in config:
         if isinstance(config["marketmultibuycheck"], int):

--- a/pycryptobot.py
+++ b/pycryptobot.py
@@ -384,8 +384,7 @@ def executeJob(
                     executeJob,
                     (sc, _app, _state, _technical_analysis, _websocket),
                 )
-    # change_pcnt_high set to 0 here to prevent errors on some tokens for some users.
-    # Need to track down main source of error.  This allows bots to launch in those instances.
+
     if len(df_last) > 0:
         now = datetime.today().strftime("%Y-%m-%d %H:%M:%S")
 
@@ -547,6 +546,7 @@ def executeJob(
             # handle immediate sell actions
             if strategy.isSellTrigger(
                 _app,
+                _state,
                 price,
                 _technical_analysis.getTradeExit(price),
                 margin,
@@ -559,7 +559,7 @@ def executeJob(
                 immediate_action = True
 
         # handle overriding wait actions (e.g. do not sell if sell at loss disabled!, do not buy in bull if bull only)
-        if not immediate_action and strategy.isWaitTrigger(_app, margin, goldencross):
+        if immediate_action is not True and strategy.isWaitTrigger(_app, margin, goldencross):
             _state.action = "WAIT"
             immediate_action = False
 
@@ -576,8 +576,8 @@ def executeJob(
 
         # If buy signal, save the price and check for decrease/increase before buying.
         trailing_buy_logtext = ""
-        if _state.action == "BUY" and immediate_action != True:
-            _state.action, _state.trailing_buy, trailing_buy_logtext = strategy.checkTrailingBuy(_app, _state, price)
+        if _state.action == "BUY" and immediate_action is not True:
+            _state.action, _state.trailing_buy, trailing_buy_logtext, immediate_action = strategy.checkTrailingBuy(_app, _state, price)
 
         bullbeartext = ""
         if _app.disableBullOnly() is True or (


### PR DESCRIPTION
## Description

- added trailingimmediatebuy option to buy as soon as trailingbuypcnt is reached, instead of waiting until candle close
- added preventloss option to enable selling prior to margin reaching 0% profit to prevent loss
- added preventlosstrigger - margin set point to start watching for preventloss (see readme)
- added preventlossmargin - margin set point to sell at for preventloss (see readme)
- reordered some test in isSellTrigger to minimize processing on every pass under some conditions
- added detailed information for trailingbuypcnt and preventloss to README file

Fixes # (issue)

## Type of change

Please make your selection.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ x] This change requires a documentation update
- [ ] This change requires a new dependency
- [ x] Code Maintainability / comments
- [ x] Code Refactoring / future-proofing

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

## Checklist:

- [ x] My code follows the style guidelines of this project
- [ x] I have performed a self-review of my own code
- [ x] I have commented my code, particularly in hard-to-understand areas
- [ x] I have made corresponding changes to the documentation
- [ x] My changes generate no new warnings
- [ ] I have added pytest unit tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ x] I have checked my code and corrected any misspellings
