### PR TITLE
average the margin_calculation on get_closed_trades in actions.py

### DIFF
--- a/models/telegram/actions.py
+++ b/models/telegram/actions.py
@@ -754,7 +754,7 @@ class TelegramActions:
                     f"Last Recorded Date: <b>{last_trade_date}</b>\n\n"
                     f"Profit: <b>{round(margin_positive,2)}%</b>  from (<b>{positive_counter}</b>) trades\n"
                     f"Loss: <b>{round(margin_negative,2)}%</b>  from (<b>{negative_counter}</b>) trades\n"
-                    f"Total: <b>{round(margin_calculation,2)}%</b>  from (<b>{trade_counter}</b>) trades"
+                    f"Total: <b>{round((margin_calculation/trade_counter),2)}%</b>  from (<b>{trade_counter}</b>) trades"
                 )
 
                 self.helper.send_telegram_message(update, summary)


### PR DESCRIPTION
## Description
The trade summary feature on the telegram returns the total gain or loss by summing all the gain(s) or loss(es) that occurred during the time under review. This does not show the actual gain or loss realized from all the trades. For example, if I had two 50USDT trades that made 10% profit margin each, the total margin the trade summary will display will be 20% and this is not actual profit realized from these trades rather the real profit is 10%.

This little hotfix hosted in  a branch "hot/fix" resolved the issue by calculating the average of the total margin realized.

Fixes # (issue)
Improper total margin calculation at the trade summary section.

## Type of change

Please make your selection.

- Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This change requires a new dependency
- [ ] Code Maintainability / comments
- [ ] Code Refactoring / future-proofing

## How Has This Been Tested?
I checked the trade summary at different intervals which returned the actual gain or loss incurred.

## Checklist:

-  My code follows the style guidelines of this project
-  I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
-  My changes generate no new warnings
- [ ] I have added pytest unit tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- I have checked my code and corrected any misspellings
