### PR TITLE
fix: Coinbase missing API key and secret when starting scanner

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Python Crypto Bot v8.2.3 (pycryptobot)
+# Python Crypto Bot v8.2.4 (pycryptobot)
 
 [![Docker](https://github.com/whittlem/pycryptobot/actions/workflows/container.yml/badge.svg)](https://github.com/whittlem/pycryptobot/actions/workflows/container.yml/badge.svg) [![Tests](https://github.com/whittlem/pycryptobot/actions/workflows/unit-tests.yml/badge.svg)](https://github.com/whittlem/pycryptobot/actions/workflows/unit-tests.yml/badge.svg)
 
@@ -38,10 +38,10 @@ Follow my Medium publication for PyCryptoBot articles
 For information about installing, using, and getting the most out of the bot... please refer to the articles on Medium!
 
 Install and Setup of PyCryptoBot 7
-https://trading-data-analysis.pro/install-and-setup-of-pycryptobot-7-f1b2c832e795
+<https://trading-data-analysis.pro/install-and-setup-of-pycryptobot-7-f1b2c832e795>
 
 PyCryptoBot 7 Live Test Results
-https://trading-data-analysis.pro/pycryptobot-7-live-test-results-b56316e0995c
+<https://trading-data-analysis.pro/pycryptobot-7-live-test-results-b56316e0995c>
 
 PyCryptoBot 7 Configuration
-https://trading-data-analysis.pro/pycryptobot-7-configuration-e314931f94
+<https://trading-data-analysis.pro/pycryptobot-7-configuration-e314931f94>

--- a/scanner.py
+++ b/scanner.py
@@ -8,6 +8,7 @@ from models.helper.TelegramBotHelper import TelegramBotHelper as TGBot
 from models.Trading import TechnicalAnalysis
 from models.exchange.binance import PublicAPI as BPublicAPI
 from models.exchange.coinbase import AuthAPI as CBAuthAPI
+from models.config.coinbase_parser import parser as coinbaseParser
 from models.exchange.coinbase_pro import PublicAPI as CPublicAPI
 from models.exchange.kucoin import PublicAPI as KPublicAPI
 from models.exchange.Granularity import Granularity
@@ -34,6 +35,8 @@ for exchange in config:
         if ex == Exchange.BINANCE:
             api = BPublicAPI(bot_config[ex.value]["api_url"])
         elif ex == Exchange.COINBASE:
+            # Read config from key file
+            coinbaseParser(app, bot_config[ex.value])
             api = CBAuthAPI(bot_config[ex.value]["api_key"], bot_config[ex.value]["api_secret"], bot_config[ex.value]["api_url"])
         elif ex == Exchange.COINBASEPRO:
             api = CPublicAPI()


### PR DESCRIPTION
## Description

Coinbase Auth API requires an API key and secret to initialize the CoinbaseAuthAPI class. PycryptoBot class' constructor migrates the API key and secret to `coinbase.key` file and second-time initialization results in a missing key and secret. Instead of adding it to the config.json to be read correctly by the code, read it from `coinbase.key` file where it is supposed to exit going forward.

Formatting using `black` added more diff to the file.

Partially fixes #832 (bullet 1)

## Type of change

Please make your selection.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This change requires a new dependency
- [ ] Code Maintainability / comments
- [ ] Code Refactoring / future-proofing

## How Has This Been Tested?

CLI script execution: `python ./scanner.py`

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added pytest unit tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
