### PR TITLE
Fix: missing Coinbase exchange in Telegram Bot and minimum quote order

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,10 +38,10 @@ Follow my Medium publication for PyCryptoBot articles
 For information about installing, using, and getting the most out of the bot... please refer to the articles on Medium!
 
 Install and Setup of PyCryptoBot 7
-https://trading-data-analysis.pro/install-and-setup-of-pycryptobot-7-f1b2c832e795
+<https://trading-data-analysis.pro/install-and-setup-of-pycryptobot-7-f1b2c832e795>
 
 PyCryptoBot 7 Live Test Results
-https://trading-data-analysis.pro/pycryptobot-7-live-test-results-b56316e0995c
+<https://trading-data-analysis.pro/pycryptobot-7-live-test-results-b56316e0995c>
 
 PyCryptoBot 7 Configuration
-https://trading-data-analysis.pro/pycryptobot-7-configuration-e314931f94
+<https://trading-data-analysis.pro/pycryptobot-7-configuration-e314931f94>

--- a/models/AppState.py
+++ b/models/AppState.py
@@ -216,11 +216,19 @@ class AppState:
                 raise Exception(f"Market not found! ({self.app.market})")
 
         elif self.app.exchange == Exchange.COINBASE:
+            product = self.api.auth_api("GET", f"api/v3/brokerage/products/{self.app.market}")
+            if len(product) == 0:
+                sys.tracebacklimit = 0
+                raise Exception(f"Market not found! ({self.app.market})")
+            
             ticker = self.api.get_ticker(self.app.market, None)
             price = float(ticker[1])
-
             quote = float(quote)
-            base_min = self.api.market_quote_increment(self.app.market, quote)
+            
+            try:
+                base_min = float(product[["base_min_size"]].values[0])
+            except Exception:
+                base_min = 0.0
 
         elif self.app.exchange == Exchange.COINBASEPRO:
             product = self.api.auth_api("GET", f"products/{self.app.market}")

--- a/telegram_bot.py
+++ b/telegram_bot.py
@@ -51,7 +51,7 @@ CHOOSING, TYPING_REPLY = range(2)
 EXCHANGE, MARKET, ANYOVERRIDES, OVERRIDES, SAVE, START = range(6)
 EXCEPT_EXCHANGE, EXCEPT_MARKET = range(2)
 
-replykeyboard = [["Coinbase Pro", "Binance", "Kucoin"]]
+replykeyboard = [["Coinbase", "Coinbase Pro", "Binance", "Kucoin"]]
 
 markup = ReplyKeyboardMarkup(replykeyboard, one_time_keyboard=True)
 


### PR DESCRIPTION
## Description

The Telegram bot doesn't display 'Coinbase' as the exchange and it seems it was intentionally left out due to an error in minimum_order_quote(). Reading the `base_min_size` in the response of the product API call fixes the issue and the bot
starts successfully. The orders are placed for both buy and sell, though there is another uncaught exception that exits the bot. It is related to `_trading_data` used before initialization which is out-of-scope of this change.

Partially Fixes #832 

## Type of change

Please make your selection.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This change requires a new dependency
- [ ] Code Maintainability / comments
- [ ] Code Refactoring / future-proofing

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added pytest unit tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
