### PR TITLE
fix: retrieve all the wallets in the account

### DIFF
--- a/models/exchange/coinbase/api.py
+++ b/models/exchange/coinbase/api.py
@@ -117,7 +117,7 @@ class AuthAPI(AuthAPIBase):
 
         # GET /api/v3/brokerage/accounts
         try:
-            df = self.auth_api("GET", "api/v3/brokerage/accounts")
+            df = self.auth_api("GET", "api/v3/brokerage/accounts", "limit=250")
         except Exception:
             return pd.DataFrame()
 


### PR DESCRIPTION
## Description

The default page size of 50 records may miss the wallet with funds, resulting in an 'Insufficient funds' error. This is an edge case as the error is only seen when a user has selected all the wallets when creating an API key.

Currently, Coinbase lists around 70 wallets and when increasing the page size to 250 the error is resolved. However, this is valid until the number of wallets is more than the maximum page size. 

## Type of change

Please make your selection.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This change requires a new dependency
- [ ] Code Maintainability / comments
- [ ] Code Refactoring / future-proofing

## How Has This Been Tested?

Manual live run of the bot using Coinbase Exchange and API keys. 

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added pytest unit tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings
